### PR TITLE
fix direction mark stripping in formatting helper

### DIFF
--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -23,7 +23,7 @@ def to_display_name(value: str) -> str:
     """Normalize *value* by removing direction markers and underscores."""
     if not value:
         return ""
-    cleaned = re.sub(r"[\u200e\u200f]", "", value)
+    cleaned = re.sub(r"[‎‏]", "", value)
     return cleaned.replace("_", " ").strip()
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,9 @@
+import pytest
+
+from bot.utils.formatting import to_display_name
+
+
+def test_to_display_name_strips_direction_and_underscores():
+    raw = "\u200eHello_\u200fWorld"
+    assert to_display_name(raw) == "Hello World"
+


### PR DESCRIPTION
## Summary
- fix to_display_name to strip Unicode direction marks correctly
- add test covering direction mark and underscore normalization

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68acd22455008329ba44696a741bd7ef