### PR TITLE
Implement Hijri year extractor

### DIFF
--- a/bot/parser/__init__.py
+++ b/bot/parser/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+
+_BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e]")
+_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+_YEAR_RE = re.compile(r"(?:^|\D)((?:13|14|15)\d{2})(?:هـ|ه)?(?:\D|$)")
+
+def extract_hijri_year(text: str | None) -> int | None:
+    """Return the Hijri year found in *text* or ``None`` if absent.
+
+    The parser normalises Arabic digits and ignores direction markers.
+    Only years in the range 1300–1600 are considered valid.
+    """
+    if not text:
+        return None
+    cleaned = _BIDI_RE.sub("", text).translate(_ARABIC_DIGITS)
+    m = _YEAR_RE.search(cleaned)
+    if m:
+        year = int(m.group(1))
+        if 1300 <= year <= 1600:
+            return year
+    return None
+
+__all__ = ["extract_hijri_year"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,11 @@
+import pytest
+
+from bot.parser import extract_hijri_year
+
+
+def test_extract_hijri_year_parses_arabic_digits():
+    assert extract_hijri_year("سنة #١٤٤٦هـ") == 1446
+
+
+def test_extract_hijri_year_returns_none_when_absent():
+    assert extract_hijri_year("لا يوجد سنة هنا") is None


### PR DESCRIPTION
## Summary
- add `extract_hijri_year` to parser with Arabic digit normalization
- cover parsing behaviour with new tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/sanity_imports.py`
- `python scripts/smoke_checks.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acecd7b1548329836fd36635ca48d1