### PR TITLE
Ensure lecture record exists when attachments uploaded

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -159,6 +159,36 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         created_by_admin_id=admin_id,
     )
 
+    lecture_attachment_categories = [
+        "board_images",
+        "slides",
+        "audio",
+        "video",
+        "mind_map",
+        "transcript",
+        "related",
+    ]
+    if category in lecture_attachment_categories:
+        lecture_title = f"محاضرة {info.lecture_no}: {info.title}"
+        lecture = await find_exact(
+            subject_id,
+            section,
+            "lecture",
+            lecture_title,
+            year_id=year_id,
+            lecturer_id=lecturer_id,
+        )
+        if not lecture:
+            await insert_material(
+                subject_id,
+                section,
+                "lecture",
+                lecture_title,
+                year_id=year_id,
+                lecturer_id=lecturer_id,
+                created_by_admin_id=admin_id,
+            )
+
     ingestion_id = await insert_ingestion(
         message.message_id, admin_id, file_unique_id=file_unique_id
     )


### PR DESCRIPTION
## Summary
- auto-create a lecture entry when uploading certain attachment categories if one does not already exist

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adecb5f77483298235657e21856f62