### PR TITLE
Remove lecturer year selection

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -137,12 +137,10 @@ async def render_state(update: Update, context: ContextTypes.DEFAULT_TYPE):
         subject_id = nav.data.get("subject_id")
         section_code = nav.data.get("section")
         lecturer_label = stack[-1][1]
-        lecturer_id = nav.data.get("lecturer_id")
-        years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
         lectures_exist = await has_lecture_category(subject_id, section_code) or False
         return await update.message.reply_text(
             f"المحاضر: {lecturer_label}\nاختر خيارًا:",
-            reply_markup=generate_lecturer_filter_keyboard(bool(years), lectures_exist),
+            reply_markup=generate_lecturer_filter_keyboard(False, lectures_exist),
         )
 
     if top_type == "year_list":
@@ -448,11 +446,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text in lect_map:
             lecturer_id = lect_map[text]
             nav.set_lecturer(text, lecturer_id)
-            years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
             lectures_exist = await list_lecture_titles_by_lecturer(subject_id, section_code, lecturer_id)
             return await update.message.reply_text(
                 f"المحاضر: {text}\nاختر خيارًا:",
-                reply_markup=generate_lecturer_filter_keyboard(bool(years), bool(lectures_exist)),
+                reply_markup=generate_lecturer_filter_keyboard(False, bool(lectures_exist)),
             )
 
     # 8.2.1) داخل قائمة المحاضر: اختر السنة/عرض كل محاضرات هذا المحاضر
@@ -468,11 +465,10 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text == CHOOSE_YEAR_FOR_LECTURER:
             years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
             if not years:
-                years_exist = False
                 lectures_exist = await list_lecture_titles_by_lecturer(subject_id, section_code, lecturer_id)
                 return await update.message.reply_text(
                     "لا توجد سنوات مرتبطة بمحاضرات هذا المحاضر.",
-                    reply_markup=generate_lecturer_filter_keyboard(years_exist, bool(lectures_exist)),
+                    reply_markup=generate_lecturer_filter_keyboard(False, bool(lectures_exist)),
                 )
             nav.push_view("year_list")
             return await update.message.reply_text(f"المحاضر: {lecturer_label}\nاختر السنة:", reply_markup=generate_years_keyboard(years))
@@ -480,10 +476,9 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text == LIST_LECTURES_FOR_LECTURER:
             titles = await list_lecture_titles_by_lecturer(subject_id, section_code, lecturer_id)
             if not titles:
-                years = await get_years_for_subject_section_lecturer(subject_id, section_code, lecturer_id)
                 return await update.message.reply_text(
                     "لا توجد محاضرات لهذا المحاضر.",
-                    reply_markup=generate_lecturer_filter_keyboard(bool(years), False),
+                    reply_markup=generate_lecturer_filter_keyboard(False, False),
                 )
             nav.push_view("lecture_list")
             return await update.message.reply_text(

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -14,7 +14,6 @@ from .constants import (
     YEAR_MENU_LECTURES,
     SECTION_LABELS,
     CATEGORY_TO_LABEL,
-    CHOOSE_YEAR_FOR_LECTURER,
     LIST_LECTURES_FOR_LECTURER,
 )
 
@@ -166,8 +165,6 @@ def generate_lecturer_filter_keyboard(
 ) -> ReplyKeyboardMarkup:
     """Provide filters when viewing a lecturer."""
     row: list[str] = []
-    if years_exist:
-        row.append(CHOOSE_YEAR_FOR_LECTURER)
     if lectures_exist:
         row.append(LIST_LECTURES_FOR_LECTURER)
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -160,9 +160,7 @@ def generate_lecture_titles_keyboard(titles: list[str]) -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
 
-def generate_lecturer_filter_keyboard(
-    years_exist: bool, lectures_exist: bool
-) -> ReplyKeyboardMarkup:
+def generate_lecturer_filter_keyboard(lectures_exist: bool) -> ReplyKeyboardMarkup:
     """Provide filters when viewing a lecturer."""
     row: list[str] = []
     if lectures_exist:

--- a/bot/keyboards/constants.py
+++ b/bot/keyboards/constants.py
@@ -42,7 +42,6 @@ CATEGORY_TO_LABEL = {
 }
 LABEL_TO_CATEGORY = {v: k for k, v in CATEGORY_TO_LABEL.items()}
 
-CHOOSE_YEAR_FOR_LECTURER   = "📅 اختر السنة"
 LIST_LECTURES_FOR_LECTURER = "📚 محاضرات هذا المحاضر"
 
 main_menu = ReplyKeyboardMarkup(
@@ -73,7 +72,6 @@ __all__ = [
     "LABEL_TO_SECTION",
     "CATEGORY_TO_LABEL",
     "LABEL_TO_CATEGORY",
-    "CHOOSE_YEAR_FOR_LECTURER",
     "LIST_LECTURES_FOR_LECTURER",
     "main_menu",
 ]


### PR DESCRIPTION
## Summary
- Drop year-selection button from lecturer filter keyboard
- Always pass `years_exist=False` when showing lecturer filters

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfafee55083298b3da21e41e6ab77