### PR TITLE
feat: prefix lecturer names with title

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -64,7 +64,7 @@ from ..keyboards.builders import (
     build_exam_menu,
 )
 
-from ..utils.formatting import arabic_ordinal, to_display_name
+from ..utils.formatting import arabic_ordinal, add_lecturer_title
 from ..utils.telegram import build_archive_link
 from ..config import ARCHIVE_CHANNEL_ID
 
@@ -394,7 +394,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     "لا يوجد محاضرون مرتبطون بهذا القسم.",
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
-            lect_map = {to_display_name(name): _id for _id, name in lecturers}
+            lect_map = {add_lecturer_title(name): _id for _id, name in lecturers}
             nav.data["lecturers_map"] = lect_map
             nav.push_view("lecturer_list")
             return await update.message.reply_text(
@@ -487,7 +487,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 )
             nav.push_view("lecture_list")
             return await update.message.reply_text(
-                f"محاضرات الدكتور {lecturer_label}:",
+                f"محاضرات {lecturer_label}:",
                 reply_markup=generate_lecture_titles_keyboard(titles),
             )
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -18,7 +18,7 @@ from .constants import (
     LIST_LECTURES_FOR_LECTURER,
 )
 
-from ..utils.formatting import arabic_ordinal, to_display_name
+from ..utils.formatting import arabic_ordinal, add_lecturer_title
 
 
 def _rows(items: list[str], cols: int = 2) -> list[list[str]]:
@@ -146,7 +146,7 @@ def generate_years_keyboard(years: list[tuple[int, str]]) -> ReplyKeyboardMarkup
 
 def generate_lecturers_keyboard(lecturers: list[tuple[int, str]]) -> ReplyKeyboardMarkup:
     """Display lecturers for the subject/section."""
-    names = [to_display_name(name) for _id, name in lecturers]
+    names = [add_lecturer_title(name) for _id, name in lecturers]
     keyboard = _rows(names, cols=2)
     keyboard.append([BACK, BACK_TO_SUBJECTS])
     keyboard.append([BACK_TO_LEVELS])

--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -27,4 +27,30 @@ def to_display_name(value: str) -> str:
     return cleaned.replace("_", " ").strip()
 
 
-__all__ = ["arabic_ordinal", "to_display_name"]
+_TITLE_PREFIXES = (
+    "الدكتور",
+    "دكتور",
+    "الدكتورة",
+    "دكتورة",
+    "أ.د",
+    "الأستاذ",
+    "الأستاذة",
+    "المهندس",
+    "المهندسة",
+    "م.",
+    "م ",
+)
+_TITLE_RE = re.compile(rf"^({'|'.join(re.escape(p) for p in _TITLE_PREFIXES)})\b")
+
+
+def add_lecturer_title(name: str, title: str = "الدكتور") -> str:
+    """Prefix *name* with *title* unless it already has one."""
+    if not name:
+        return ""
+    cleaned = to_display_name(name)
+    if _TITLE_RE.match(cleaned):
+        return cleaned
+    return f"{title} {cleaned}"
+
+
+__all__ = ["arabic_ordinal", "to_display_name", "add_lecturer_title"]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,9 +1,17 @@
 import pytest
 
-from bot.utils.formatting import to_display_name
+from bot.utils.formatting import to_display_name, add_lecturer_title
 
 
 def test_to_display_name_strips_direction_and_underscores():
     raw = "\u200eHello_\u200fWorld"
     assert to_display_name(raw) == "Hello World"
+
+
+def test_add_lecturer_title_adds_prefix_when_missing():
+    assert add_lecturer_title("فلان") == "الدكتور فلان"
+
+
+def test_add_lecturer_title_keeps_existing():
+    assert add_lecturer_title("الدكتور علان") == "الدكتور علان"
 


### PR DESCRIPTION
## Summary
- add helper to prepend lecturer titles
- show lecturer buttons with "الدكتور" prefix
- clean up lecturer name displays in navigation

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfb00b0a883298b94472d46ed4243