### PR TITLE
Ensure lecturer names are prefixed with title

### DIFF
--- a/bot/handlers/navigation.py
+++ b/bot/handlers/navigation.py
@@ -64,7 +64,7 @@ from ..keyboards.builders import (
     build_exam_menu,
 )
 
-from ..utils.formatting import arabic_ordinal, to_display_name
+from ..utils.formatting import arabic_ordinal, format_lecturer_name
 from ..utils.telegram import build_archive_link
 from ..config import ARCHIVE_CHANNEL_ID
 
@@ -430,7 +430,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     "لا يوجد محاضرون مرتبطون بهذا القسم.",
                     reply_markup=generate_subject_sections_keyboard_dynamic([]),
                 )
-            lect_map = {to_display_name(name): _id for _id, name in lecturers}
+            lect_map = {format_lecturer_name(name): _id for _id, name in lecturers}
             nav.data["lecturers_map"] = lect_map
             nav.push_view("lecturer_list")
             return await update.message.reply_text(
@@ -544,7 +544,7 @@ async def echo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
             nav.push_view("lecture_list")
             nav.data["lectures_map"] = lectures_map
             return await update.message.reply_text(
-                f"محاضرات الدكتور {lecturer_label}:",
+                f"محاضرات {lecturer_label}:",
                 reply_markup=markup,
             )
 

--- a/bot/keyboards/builders.py
+++ b/bot/keyboards/builders.py
@@ -17,7 +17,7 @@ from .constants import (
     LIST_LECTURES_FOR_LECTURER,
 )
 
-from ..utils.formatting import arabic_ordinal, to_display_name
+from ..utils.formatting import arabic_ordinal, format_lecturer_name
 
 
 def _rows(items: list[str], cols: int = 2) -> list[list[str]]:
@@ -145,7 +145,7 @@ def generate_years_keyboard(years: list[tuple[int, str]]) -> ReplyKeyboardMarkup
 
 def generate_lecturers_keyboard(lecturers: list[tuple[int, str]]) -> ReplyKeyboardMarkup:
     """Display lecturers for the subject/section."""
-    names = [to_display_name(name) for _id, name in lecturers]
+    names = [format_lecturer_name(name) for _id, name in lecturers]
     keyboard = _rows(names, cols=2)
     keyboard.append([BACK, BACK_TO_SUBJECTS])
     keyboard.append([BACK_TO_LEVELS])

--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -27,4 +27,23 @@ def to_display_name(value: str) -> str:
     return cleaned.replace("_", " ").strip()
 
 
-__all__ = ["arabic_ordinal", "to_display_name"]
+def format_lecturer_name(name: str, title: str = "الدكتور") -> str:
+    """Return *name* prefixed with *title* if not already titled.
+
+    The input is first normalized using :func:`to_display_name`.  If the
+    resulting name already starts with a common academic title (e.g. ``"د."``
+    or ``"الدكتور"``/``"الدكتورة"``), it is returned unchanged.  Otherwise
+    the provided *title* is prepended.
+    """
+
+    display = to_display_name(name)
+    if not display:
+        return ""
+
+    prefixes = ("د.", "دكتور", "الدكتور", "دكتورة", "الدكتورة")
+    if any(display.startswith(p) for p in prefixes):
+        return display
+    return f"{title} {display}"
+
+
+__all__ = ["arabic_ordinal", "to_display_name", "format_lecturer_name"]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,9 +1,21 @@
 import pytest
 
-from bot.utils.formatting import to_display_name
+from bot.utils.formatting import to_display_name, format_lecturer_name
 
 
 def test_to_display_name_strips_direction_and_underscores():
     raw = "\u200eHello_\u200fWorld"
     assert to_display_name(raw) == "Hello World"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("صالح", "الدكتور صالح"),
+        ("الدكتور صالح", "الدكتور صالح"),
+        ("د. صالح", "د. صالح"),
+    ],
+)
+def test_format_lecturer_name(raw: str, expected: str) -> None:
+    assert format_lecturer_name(raw) == expected
 


### PR DESCRIPTION
## Summary
- add `format_lecturer_name` helper to normalize lecturer names and prefix with a title if missing
- use the helper in lecturer keyboard and navigation flows
- expand formatting tests for lecturer titles

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0080939c83299c154210e9fd2a60