### PR TITLE
Prune orphan levels/topics and filter empty subject listings

### DIFF
--- a/bot/db/topics.py
+++ b/bot/db/topics.py
@@ -52,6 +52,19 @@ async def bind(tg_chat_id: int, tg_topic_id: int, subject_id: int, section: str)
             (group_id, tg_topic_id, subject_id, section),
         )
         await db.commit()
+    await cleanup_orphan_topics()
 
 
-__all__ = ["get_group_id_by_chat", "get_binding", "bind"]
+async def cleanup_orphan_topics() -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            DELETE FROM topics
+            WHERE group_id NOT IN (SELECT id FROM groups)
+               OR subject_id NOT IN (SELECT id FROM subjects)
+            """
+        )
+        await db.commit()
+
+
+__all__ = ["get_group_id_by_chat", "get_binding", "bind", "cleanup_orphan_topics"]


### PR DESCRIPTION
## Summary
- add `cleanup_unused_levels_terms` to remove levels/terms not tied to any group and call it after group upserts
- add `cleanup_orphan_topics` to purge topics missing group or subject references after binding
- ensure subject navigation queries only list levels, terms and subjects that actually have materials

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4645a599c8329977352332e79221c