### PR TITLE
Use ephemeral replies for confirmation and rejection messages

### DIFF
--- a/bot/utils/telegram.py
+++ b/bot/utils/telegram.py
@@ -48,10 +48,13 @@ async def send_ephemeral(
     context: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
     text: str,
-    seconds: int = 7,
+    seconds: int = 10,
+    reply_to_message_id: int | None = None,
 ):
     """Send a message that auto-deletes after ``seconds`` seconds."""
-    msg = await context.bot.send_message(chat_id, text)
+    msg = await context.bot.send_message(
+        chat_id, text, reply_to_message_id=reply_to_message_id
+    )
 
     async def _delete(ctx: ContextTypes.DEFAULT_TYPE):
         try:


### PR DESCRIPTION
## Summary
- Extend `send_ephemeral` with optional `reply_to_message_id` and increase auto-delete timeout to 10 seconds
- Swap direct reply/send calls in ingestion and approvals handlers for `send_ephemeral` to keep chats clean

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b46a9b911083298171dbdebbce3275