### PR TITLE
Ensure duplicate handling limited to original uploader

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -295,6 +295,11 @@ async def handle_duplicate_decision(
     if data is None:
         await query.edit_message_text("انتهت صلاحية الطلب.")
         return
+    if query.from_user.id != data["admin_id"]:
+        await send_ephemeral(
+            context, query.message.chat_id, "العملية مخصّصة لمرسل الملف"
+        )
+        return
     if action == "cancel":
         ctx.pop(msg_id, None)
         await send_ephemeral(context, query.message.chat_id, "تم الإلغاء.")


### PR DESCRIPTION
## Summary
- Verify duplicate decision callbacks are from the original uploader
- Inform other users that the operation is restricted to the file sender

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b479e2b4a48329b8ed49f076c84219