### PR TITLE
Ensure duplicate decision prompts are cleared after answering

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -300,6 +300,10 @@ async def handle_duplicate_decision(
             context, query.message.chat_id, "العملية مخصّصة لمرسل الملف"
         )
         return
+    try:
+        await query.message.delete()
+    except Exception:
+        await query.edit_message_reply_markup(None)
     if action == "cancel":
         ctx.pop(msg_id, None)
         await send_ephemeral(context, query.message.chat_id, "تم الإلغاء.")


### PR DESCRIPTION
## Summary
- Delete the duplicate decision message after processing or fallback to clearing its buttons
- Guarantee the cleanup occurs for both replace and cancel actions

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b47abce0b4832994e55766778d9df4