### PR TITLE
feat: add duplicate message deletion option

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -3,7 +3,11 @@
 from .start import start
 from .navigation import echo_handler
 from .topics import insert_sub_conv, insert_sub_private
-from .ingestion import ingestion_handler, duplicate_callback
+from .ingestion import (
+    ingestion_handler,
+    duplicate_callback,
+    duplicate_cancel_callback,
+)
 from .groups import insert_group_conv, insert_group_private
 from .admins import admins_conv
 from .approvals import approvals_handler, approval_callback
@@ -17,6 +21,7 @@ __all__ = [
     "insert_sub_private",
     "ingestion_handler",
     "duplicate_callback",
+    "duplicate_cancel_callback",
     "insert_group_conv",
     "insert_group_private",
     "admins_conv",

--- a/bot/main.py
+++ b/bot/main.py
@@ -22,6 +22,7 @@ from .handlers import (
     insert_sub_private,
     ingestion_handler,
     duplicate_callback,
+    duplicate_cancel_callback,
     insert_group_conv,
     insert_group_private,
     admins_conv,
@@ -73,6 +74,7 @@ def main():
     app.add_handler(approvals_handler)
     app.add_handler(approval_callback)
     app.add_handler(duplicate_callback)
+    app.add_handler(duplicate_cancel_callback)
     app.add_handler(
         MessageHandler(filters.ALL & filters.ChatType.GROUPS, moderation_handler),
         group=-1,


### PR DESCRIPTION
## Summary
- prompt users to keep or delete original message after cancelling duplicate replacement
- add callback handler for keep/delete actions and wire into app

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47b78bf6c8329bda0eae4b8447804