### PR TITLE
Support topic-aware ephemeral messages

### DIFF
--- a/bot/handlers/groups.py
+++ b/bot/handlers/groups.py
@@ -120,10 +120,20 @@ async def insert_group_confirm(update: Update, context: ContextTypes.DEFAULT_TYP
             info["term_id"],
         )
         await conv_cleanup(context, context.bot, update.effective_chat.id)
-        await send_ephemeral(context, update.effective_chat.id, "تم الربط بنجاح.")
+        await send_ephemeral(
+            context,
+            update.effective_chat.id,
+            "تم الربط بنجاح.",
+            message_thread_id=query.message.message_thread_id,
+        )
     else:
         await conv_cleanup(context, context.bot, update.effective_chat.id)
-        await send_ephemeral(context, update.effective_chat.id, "تم الإلغاء.")
+        await send_ephemeral(
+            context,
+            update.effective_chat.id,
+            "تم الإلغاء.",
+            message_thread_id=query.message.message_thread_id,
+        )
     context.chat_data.pop("insert_group", None)
     return ConversationHandler.END
 

--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -189,10 +189,20 @@ async def insert_sub_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE)
             info["section"],
         )
         await conv_cleanup(context, context.bot, chat.id)
-        await send_ephemeral(context, chat.id, "تم الربط بنجاح.")
+        await send_ephemeral(
+            context,
+            chat.id,
+            "تم الربط بنجاح.",
+            message_thread_id=info.get("thread_id"),
+        )
     else:
         await conv_cleanup(context, context.bot, chat.id)
-        await send_ephemeral(context, chat.id, "تم الإلغاء.")
+        await send_ephemeral(
+            context,
+            chat.id,
+            "تم الإلغاء.",
+            message_thread_id=info.get("thread_id"),
+        )
     context.chat_data.pop("insert_sub", None)
     return ConversationHandler.END
 

--- a/bot/utils/telegram.py
+++ b/bot/utils/telegram.py
@@ -52,13 +52,17 @@ async def send_ephemeral(
     text: str,
     seconds: int = 10,
     reply_to_message_id: int | None = None,
+    message_thread_id: int | None = None,
 ):
     """Send a message that auto-deletes after ``seconds`` seconds.
 
     The bot must possess the ``Delete messages`` right in group chats.
     """
     msg = await context.bot.send_message(
-        chat_id, text, reply_to_message_id=reply_to_message_id
+        chat_id,
+        text,
+        reply_to_message_id=reply_to_message_id,
+        message_thread_id=message_thread_id,
     )
 
     async def delete_later() -> None:


### PR DESCRIPTION
## Summary
- add optional `message_thread_id` to `send_ephemeral`
- pass thread IDs in group/topic handlers so replies stay in the same topic
- include thread ID in direct `send_message` calls inside topics

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b483eb6ba483298d41abfd4661e90c