### PR TITLE
Restrict duplicate actions to uploader or owner

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -16,6 +16,7 @@ from ..db import (
     insert_term_resource,
 )
 from ..db.materials import insert_material, find_exact
+from bot.db.admins import is_owner
 from ..parser.hashtags import parse_hashtags
 from ..utils.telegram import send_ephemeral, get_file_unique_id_from_message
 
@@ -193,6 +194,7 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             "chat_id": chat.id,
             "thread_id": thread_id,
             "admin_id": admin_id,
+            "tg_user_id": user.id,
             "subject_name": subject_name,
             "section": section,
             "category": category,
@@ -310,7 +312,7 @@ async def handle_duplicate_decision(
     if data is None:
         await query.edit_message_text("انتهت صلاحية الطلب.")
         return
-    if query.from_user.id != data["admin_id"]:
+    if query.from_user.id != data["tg_user_id"] and not is_owner(query.from_user.id):
         await send_ephemeral(
             context,
             query.message.chat_id,

--- a/tests/test_duplicate_permissions.py
+++ b/tests/test_duplicate_permissions.py
@@ -1,0 +1,68 @@
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Ensure required environment variables for importing bot modules
+os.environ.setdefault("BOT_TOKEN", "test")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+from bot.handlers.ingestion import handle_duplicate_decision
+
+
+class DummyMessage:
+    def __init__(self):
+        self.chat_id = 123
+        self.message_thread_id = None
+        self.deleted = False
+
+    async def delete(self):
+        self.deleted = True
+
+
+class DummyQuery:
+    def __init__(self, user_id):
+        self.from_user = SimpleNamespace(id=user_id)
+        self.data = "dup:cancel:1:0"
+        self.message = DummyMessage()
+
+    async def answer(self):
+        pass
+
+    async def edit_message_text(self, text):
+        self.edited_text = text
+
+    async def edit_message_reply_markup(self, markup):
+        self.edited_markup = markup
+
+
+def _make_context():
+    ctx = {"replace_ctx": {1: {"tg_user_id": 42, "admin_id": 5}}}
+    bot = SimpleNamespace(send_message=AsyncMock())
+    return SimpleNamespace(user_data=ctx, bot=bot)
+
+
+def _run(user_id, owner_flag):
+    query = DummyQuery(user_id)
+    context = _make_context()
+    update = SimpleNamespace(callback_query=query)
+
+    async def runner():
+        with patch("bot.handlers.ingestion.send_ephemeral", AsyncMock()), patch(
+            "bot.handlers.ingestion.is_owner", return_value=owner_flag
+        ):
+            await handle_duplicate_decision(update, context)
+        return query.message.deleted
+
+    return asyncio.run(runner())
+
+
+def test_sender_can_cancel_duplicate():
+    assert _run(42, False)
+
+
+def test_owner_can_cancel_duplicate():
+    assert _run(1, True)


### PR DESCRIPTION
## Summary
- Track `tg_user_id` when saving duplicate-replacement context
- Allow duplicate replacement actions only by original sender or bot owner
- Add unit tests covering sender and owner permissions on duplicate cancellation

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49337a3648329abd278fe45fb59fb