### PR TITLE
Add simple NavStack utility for navigation state

### DIFF
--- a/bot/navigation/__init__.py
+++ b/bot/navigation/__init__.py
@@ -1,5 +1,6 @@
 from .state import NavigationState
+from .nav_stack import NavStack
 from .tree import Node, invalidate
 
-__all__ = ["NavigationState", "Node", "invalidate"]
+__all__ = ["NavigationState", "NavStack", "Node", "invalidate"]
 

--- a/bot/navigation/nav_stack.py
+++ b/bot/navigation/nav_stack.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple, Optional
+
+# Key used to store the navigation stack in ``context.user_data``
+NAV_STACK_KEY = "nav_stack"
+
+# Node representation: (kind, id, title)
+Node = Tuple[str, Optional[int | str], str]
+
+
+class NavStack:
+    """Simple navigation stack backed by ``context.user_data``.
+
+    The stack is stored under :data:`NAV_STACK_KEY` in ``user_data`` and uses a
+    list of tuples ``(kind, id, title)`` to ease serialization.
+    """
+
+    def __init__(self, user_data: Dict) -> None:
+        stack = user_data.get(NAV_STACK_KEY)
+        if not isinstance(stack, list):
+            stack = []
+            user_data[NAV_STACK_KEY] = stack
+        self._user_data = user_data
+        self._stack: List[Node] = stack
+
+    # ------------------------------------------------------------------
+    # Basic stack operations
+    def push(self, node: Node) -> None:
+        """Push ``node`` onto the stack."""
+        self._stack.append(node)
+
+    def pop(self) -> Optional[Node]:
+        """Pop and return the top node if present."""
+        if self._stack:
+            return self._stack.pop()
+        return None
+
+    def peek(self) -> Optional[Node]:
+        """Return the top node without removing it."""
+        if self._stack:
+            return self._stack[-1]
+        return None
+
+    # ------------------------------------------------------------------
+    def path_text(self) -> str:
+        """Return a textual representation of the current path."""
+        return " / ".join(title for _, _, title in self._stack if title)

--- a/tests/test_nav_stack.py
+++ b/tests/test_nav_stack.py
@@ -1,0 +1,29 @@
+from bot.navigation import NavStack
+
+
+def test_nav_stack_basic_operations():
+    user_data = {}
+    stack = NavStack(user_data)
+
+    # initial stack created under NAV_STACK_KEY
+    assert user_data["nav_stack"] == []
+
+    node1 = ("level", 1, "Level 1")
+    node2 = ("term", 2, "Term 1")
+
+    stack.push(node1)
+    stack.push(node2)
+
+    assert stack.peek() == node2
+    assert stack.path_text() == "Level 1 / Term 1"
+
+    popped = stack.pop()
+    assert popped == node2
+    assert stack.peek() == node1
+    assert stack.path_text() == "Level 1"
+
+    assert stack.pop() == node1
+    # popping from empty returns None
+    assert stack.pop() is None
+    assert stack.peek() is None
+    assert stack.path_text() == ""


### PR DESCRIPTION
## Summary
- expose new `NavStack` class to manage a list of navigation nodes in `context.user_data`
- stack supports `push`, `pop`, `peek` and `path_text` helpers
- cover NavStack behaviour with unit tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d29510748329b8c4e2c65d069c64