### PR TITLE
feat: add paginated keyboard builder

### DIFF
--- a/bot/config/__init__.py
+++ b/bot/config/__init__.py
@@ -14,6 +14,7 @@ OWNER_TG_ID = config.OWNER_TG_ID
 ADMIN_USER_IDS = config.ADMIN_USER_IDS
 VERSION = config.VERSION
 START_TIME = config.START_TIME
+PER_PAGE = config.PER_PAGE
 
 __all__ = [
     "config",
@@ -25,4 +26,5 @@ __all__ = [
     "ADMIN_USER_IDS",
     "VERSION",
     "START_TIME",
+    "PER_PAGE",
 ]

--- a/bot/config/config.py
+++ b/bot/config/config.py
@@ -21,6 +21,7 @@ class Config:
     ADMIN_USER_IDS: List[int]
     VERSION: str
     START_TIME: datetime
+    PER_PAGE: int
 
     @staticmethod
     def _to_int(key: str, *, required: bool = False) -> Optional[int]:
@@ -53,6 +54,7 @@ class Config:
 
         version = os.getenv("COMMIT_SHA", "dev")
         start_time = datetime.now()
+        per_page = cls._to_int("PER_PAGE", required=False) or 8
 
         return cls(
             BOT_TOKEN=bot_token,
@@ -62,4 +64,5 @@ class Config:
             ADMIN_USER_IDS=admin_user_ids,
             VERSION=version,
             START_TIME=start_time,
+            PER_PAGE=per_page,
         )

--- a/bot/keyboards/builders/__init__.py
+++ b/bot/keyboards/builders/__init__.py
@@ -1,6 +1,6 @@
 from telegram import ReplyKeyboardMarkup
 
-from .constants import (
+from ..constants import (
     TERM_MENU_SHOW_SUBJECTS,
     TERM_MENU_PLAN,
     TERM_MENU_LINKS,
@@ -17,7 +17,7 @@ from .constants import (
     LIST_LECTURES_FOR_LECTURER,
 )
 
-from ..utils.formatting import arabic_ordinal, format_lecturer_name
+from ...utils.formatting import arabic_ordinal, format_lecturer_name
 
 
 def _rows(items: list[str], cols: int = 2) -> list[list[str]]:
@@ -267,3 +267,7 @@ __all__ = [
     "build_types_menu",
     "build_exam_menu",
 ]
+
+from .paginated import build_children_keyboard
+
+__all__ += ["build_children_keyboard"]

--- a/bot/keyboards/builders/paginated.py
+++ b/bot/keyboards/builders/paginated.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from math import ceil
+from typing import Sequence, Tuple
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from ...config import PER_PAGE
+
+
+def build_children_keyboard(
+    children: Sequence[Tuple[str, int | str, str]],
+    page: int,
+    per_page: int | None = None,
+) -> InlineKeyboardMarkup:
+    """Build a paginated inline keyboard for navigation children.
+
+    Parameters
+    ----------
+    children:
+        Sequence of triples ``(kind, id, label)`` describing each child node.
+    page:
+        One-based page number to render.
+    per_page:
+        Number of items to show per page.  Defaults to the global
+        :data:`PER_PAGE` configuration value when ``None``.
+    """
+
+    if per_page is None:
+        per_page = PER_PAGE
+
+    total = len(children)
+    if per_page <= 0:
+        per_page = total or 1
+    pages = max(1, ceil(total / per_page))
+    page = max(1, min(page, pages))
+
+    start = (page - 1) * per_page
+    end = start + per_page
+
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for kind, ident, label in children[start:end]:
+        keyboard.append([
+            InlineKeyboardButton(text=label, callback_data=f"{kind}:{ident}")
+        ])
+
+    nav_row: list[InlineKeyboardButton] = []
+    if page > 1:
+        nav_row.append(
+            InlineKeyboardButton(text="◀", callback_data=f"page:{page - 1}")
+        )
+    if page < pages:
+        nav_row.append(
+            InlineKeyboardButton(text="▶", callback_data=f"page:{page + 1}")
+        )
+    if nav_row:
+        keyboard.append(nav_row)
+
+    keyboard.append([InlineKeyboardButton(text="🔙", callback_data="back")])
+    return InlineKeyboardMarkup(keyboard)

--- a/tests/test_paginated_keyboard.py
+++ b/tests/test_paginated_keyboard.py
@@ -1,0 +1,29 @@
+from bot.keyboards.builders.paginated import build_children_keyboard
+
+
+def _make_children(n: int):
+    return [("kind", i, f"Item {i}") for i in range(1, n + 1)]
+
+
+def test_build_children_keyboard_first_page():
+    children = _make_children(5)
+    markup = build_children_keyboard(children, page=1, per_page=2)
+    # two items on first page
+    assert markup.inline_keyboard[0][0].callback_data == "kind:1"
+    assert markup.inline_keyboard[1][0].callback_data == "kind:2"
+    # navigation row should point to next page only
+    assert markup.inline_keyboard[2][0].callback_data == "page:2"
+    # back button exists
+    assert markup.inline_keyboard[3][0].callback_data == "back"
+
+
+def test_build_children_keyboard_middle_page():
+    children = _make_children(5)
+    markup = build_children_keyboard(children, page=2, per_page=2)
+    # items 3 and 4
+    assert markup.inline_keyboard[0][0].callback_data == "kind:3"
+    assert markup.inline_keyboard[1][0].callback_data == "kind:4"
+    # navigation row has prev and next
+    assert [b.callback_data for b in markup.inline_keyboard[2]] == ["page:1", "page:3"]
+    # back button
+    assert markup.inline_keyboard[3][0].callback_data == "back"


### PR DESCRIPTION
## Summary
- add paginated inline keyboard builder with navigation buttons
- expose `PER_PAGE` setting for pagination configuration

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d407e15c83298a7fcb5d1e73670a