### PR TITLE
Add navigation tree handler and callback support

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -13,6 +13,7 @@ from .admins import admins_conv
 from .approvals import approvals_handler, approval_callback
 from .moderation import moderation_handler
 from .misc import me_handler, version_handler
+from .navigation_tree import navtree_start, navtree_callback
 
 __all__ = [
     "start",
@@ -30,4 +31,6 @@ __all__ = [
     "moderation_handler",
     "me_handler",
     "version_handler",
+    "navtree_start",
+    "navtree_callback",
 ]

--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+"""Handlers for exploring the navigation tree via inline keyboards."""
+
+from typing import Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..navigation.nav_stack import NavStack
+from ..navigation.tree import get_children, CHILD_KIND
+from ..keyboards.builders.paginated import build_children_keyboard
+
+
+async def _render(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    kind: str,
+    ident: Optional[int | str],
+    page: int,
+) -> None:
+    """Render children for ``kind``/``ident`` at ``page``."""
+
+    user_id = update.effective_user.id if update.effective_user else None
+    children_raw = await get_children(kind, ident, user_id)
+    child_kind = CHILD_KIND.get(kind, kind)
+    children = [
+        (
+            child_kind,
+            item[0] if isinstance(item, (tuple, list)) else item,
+            item[1] if isinstance(item, (tuple, list)) else str(item),
+        )
+        for item in children_raw
+    ]
+
+    keyboard = build_children_keyboard(children, page)
+    text = NavStack(context.user_data).path_text() or "اختر عنصرًا:"
+
+    if update.callback_query:
+        await update.callback_query.answer()
+        await update.callback_query.edit_message_text(text, reply_markup=keyboard)
+    else:
+        await update.message.reply_text(text, reply_markup=keyboard)
+
+
+def _parse_id(value: str) -> int | str:
+    return int(value) if value.isdigit() else value
+
+
+async def _render_current(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, page: int = 1
+) -> None:
+    stack = NavStack(context.user_data)
+    node = stack.peek()
+    if node is None:
+        kind, ident = "root", None
+    else:
+        kind, ident, _ = node
+    await _render(update, context, kind, ident, page)
+
+
+async def navtree_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Start navigation at the root of the tree."""
+
+    stack = NavStack(context.user_data)
+    while stack.pop():
+        pass
+    await _render(update, context, "root", None, 1)
+
+
+async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Unified callback query handler for navigation tree buttons."""
+
+    query = update.callback_query
+    data = query.data if query else ""
+    stack = NavStack(context.user_data)
+
+    if data == "back":
+        stack.pop()
+        await _render_current(update, context, 1)
+        if query:
+            await query.answer()
+        return
+
+    if data.startswith("page:"):
+        page = int(data.split(":", 1)[1])
+        await _render_current(update, context, page)
+        if query:
+            await query.answer()
+        return
+
+    if ":" in data:
+        kind, ident_str = data.split(":", 1)
+        ident = _parse_id(ident_str)
+        parent = stack.peek()
+        parent_kind = parent[0] if parent else "root"
+        parent_id = parent[1] if parent else None
+        user_id = query.from_user.id if query and query.from_user else None
+        children_raw = await get_children(parent_kind, parent_id, user_id)
+        label = ""
+        for item in children_raw:
+            item_id = item[0] if isinstance(item, (tuple, list)) else item
+            item_label = item[1] if isinstance(item, (tuple, list)) else str(item)
+            if str(item_id) == ident_str:
+                label = item_label
+                break
+        stack.push((kind, ident, label))
+        await _render(update, context, kind, ident, 1)
+        if query:
+            await query.answer()
+        return
+
+    if query:
+        await query.answer()

--- a/bot/main.py
+++ b/bot/main.py
@@ -9,6 +9,7 @@ from telegram.ext import (
     ApplicationBuilder,
     CommandHandler,
     MessageHandler,
+    CallbackQueryHandler,
     filters,
 )
 
@@ -31,6 +32,8 @@ from .handlers import (
     moderation_handler,
     me_handler,
     version_handler,
+    navtree_start,
+    navtree_callback,
 )
 from .jobs import purge_temp_archives
 from datetime import time
@@ -62,6 +65,7 @@ def main():
     app.add_handler(CommandHandler("start", start, filters.ChatType.PRIVATE))
     app.add_handler(CommandHandler("insert_group", insert_group_private, filters.ChatType.PRIVATE))
     app.add_handler(CommandHandler("insert_sub", insert_sub_private, filters.ChatType.PRIVATE))
+    app.add_handler(CommandHandler("nav", navtree_start, filters.ChatType.PRIVATE))
     app.add_handler(me_handler)
     app.add_handler(version_handler)
 
@@ -75,6 +79,7 @@ def main():
     app.add_handler(approval_callback)
     app.add_handler(duplicate_callback)
     app.add_handler(duplicate_cancel_callback)
+    app.add_handler(CallbackQueryHandler(navtree_callback))
     app.add_handler(
         MessageHandler(filters.ALL & filters.ChatType.GROUPS, moderation_handler),
         group=-1,


### PR DESCRIPTION
## Summary
- Add inline navigation tree start and callback handlers
- Register navigation tree command and callback handlers in main application

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4d98d5118832986b47a273a0ee940