### PR TITLE
cache last children for page navigation

### DIFF
--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -3,13 +3,55 @@ from __future__ import annotations
 """Handlers for exploring the navigation tree via inline keyboards."""
 
 from typing import Optional
+import time
 
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from ..navigation.nav_stack import NavStack
-from ..navigation.tree import get_children, CHILD_KIND
+from ..navigation.tree import get_children, CHILD_KIND, CACHE_TTL_SECONDS
 from ..keyboards.builders.paginated import build_children_keyboard
+
+# Key used to cache the most recently fetched children list.
+LAST_CHILDREN_KEY = "last_children"
+# Reuse the same TTL as the DB layer cache to keep behaviour consistent.
+LAST_CHILDREN_TTL_SECONDS = CACHE_TTL_SECONDS
+
+
+async def _load_children(
+    context: ContextTypes.DEFAULT_TYPE,
+    kind: str,
+    ident: Optional[int | str],
+    user_id: int | None,
+):
+    """Return children for ``kind``/``ident`` using a short-lived cache."""
+
+    node_key = (kind, ident)
+    now = time.time()
+    cached = context.user_data.get(LAST_CHILDREN_KEY)
+    if (
+        isinstance(cached, dict)
+        and cached.get("node_key") == node_key
+        and now - cached.get("timestamp", 0) < LAST_CHILDREN_TTL_SECONDS
+    ):
+        return cached["children"]
+
+    children_raw = await get_children(kind, ident, user_id)
+    child_kind = CHILD_KIND.get(kind, kind)
+    children = [
+        (
+            child_kind,
+            item[0] if isinstance(item, (tuple, list)) else item,
+            item[1] if isinstance(item, (tuple, list)) else str(item),
+        )
+        for item in children_raw
+    ]
+    context.user_data[LAST_CHILDREN_KEY] = {
+        "node_key": node_key,
+        "timestamp": now,
+        "children": children,
+    }
+    return children
 
 
 async def _render(
@@ -22,16 +64,7 @@ async def _render(
     """Render children for ``kind``/``ident`` at ``page``."""
 
     user_id = update.effective_user.id if update.effective_user else None
-    children_raw = await get_children(kind, ident, user_id)
-    child_kind = CHILD_KIND.get(kind, kind)
-    children = [
-        (
-            child_kind,
-            item[0] if isinstance(item, (tuple, list)) else item,
-            item[1] if isinstance(item, (tuple, list)) else str(item),
-        )
-        for item in children_raw
-    ]
+    children = await _load_children(context, kind, ident, user_id)
 
     keyboard = build_children_keyboard(children, page)
     text = NavStack(context.user_data).path_text() or "اختر عنصرًا:"
@@ -96,11 +129,9 @@ async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         parent_kind = parent[0] if parent else "root"
         parent_id = parent[1] if parent else None
         user_id = query.from_user.id if query and query.from_user else None
-        children_raw = await get_children(parent_kind, parent_id, user_id)
+        children = await _load_children(context, parent_kind, parent_id, user_id)
         label = ""
-        for item in children_raw:
-            item_id = item[0] if isinstance(item, (tuple, list)) else item
-            item_label = item[1] if isinstance(item, (tuple, list)) else str(item)
+        for _, item_id, item_label in children:
             if str(item_id) == ident_str:
                 label = item_label
                 break

--- a/tests/test_last_children_cache.py
+++ b/tests/test_last_children_cache.py
@@ -1,0 +1,36 @@
+import asyncio
+from importlib import import_module
+
+
+class DummyContext:
+    def __init__(self):
+        self.user_data = {}
+
+def test_load_children_cache(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "x")
+    monkeypatch.setenv("ARCHIVE_CHANNEL_ID", "1")
+    monkeypatch.setenv("OWNER_TG_ID", "1")
+    navigation_tree = import_module("bot.handlers.navigation_tree")
+
+    calls = {"count": 0}
+
+    async def fake_get_children(kind, ident, user_id):
+        calls["count"] += 1
+        return [(1, "Item 1"), (2, "Item 2")]
+
+    monkeypatch.setattr(navigation_tree, "get_children", fake_get_children)
+
+    async def run():
+        ctx = DummyContext()
+        children1 = await navigation_tree._load_children(ctx, "root", None, None)
+        assert calls["count"] == 1
+        children2 = await navigation_tree._load_children(ctx, "root", None, None)
+        assert calls["count"] == 1
+        assert children1 == children2
+        ctx.user_data[navigation_tree.LAST_CHILDREN_KEY]["timestamp"] -= (
+            navigation_tree.LAST_CHILDREN_TTL_SECONDS + 1
+        )
+        await navigation_tree._load_children(ctx, "root", None, None)
+        assert calls["count"] == 2
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- cache last rendered children in context.user_data with node key and timestamp
- use cached children for page navigation if within TTL
- test navigation children cache behavior

## Testing
- `BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4daed5b20832988e0b8546b976ce1