### PR TITLE
Add indexes for admins and materials and verify usage

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -57,15 +57,18 @@ CREATE TABLE IF NOT EXISTS lecturers (
 );
 
 -- حسابات إدارية
- CREATE TABLE IF NOT EXISTS admins (
-     id INTEGER PRIMARY KEY AUTOINCREMENT,
-     tg_user_id INTEGER UNIQUE,
-     name TEXT,
-     role TEXT NOT NULL,
-     permissions_mask INTEGER NOT NULL,
-     level_scope TEXT DEFAULT 'all',
-     is_active INTEGER NOT NULL DEFAULT 1
- );
+CREATE TABLE IF NOT EXISTS admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tg_user_id INTEGER UNIQUE,
+    name TEXT,
+    role TEXT NOT NULL,
+    permissions_mask INTEGER NOT NULL,
+    level_scope TEXT DEFAULT 'all',
+    is_active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_admins_tg_user_id
+ON admins(tg_user_id);
 
 -- مجموعات تيليجرام
 CREATE TABLE IF NOT EXISTS groups (
@@ -161,6 +164,9 @@ ON materials(lecturer_id);
 
 CREATE INDEX IF NOT EXISTS idx_materials_admin
 ON materials(created_by_admin_id);
+
+CREATE INDEX IF NOT EXISTS idx_materials_section_created_at
+ON materials(section, created_at);
 
 -- موارد مرتبطة بالترم (مثل جدول الحضور)
 CREATE TABLE IF NOT EXISTS term_resources (

--- a/scripts/verify_index_usage.py
+++ b/scripts/verify_index_usage.py
@@ -1,0 +1,55 @@
+"""Verify that important queries make use of database indexes.
+
+This script creates an in-memory SQLite database using the schema from
+``database/init.sql`` and runs ``EXPLAIN QUERY PLAN`` on a few typical
+queries.  The output should reference the indexes defined in the schema,
+confirming they will be used by SQLite.
+"""
+
+from pathlib import Path
+import sqlite3
+
+
+def explain(cursor: sqlite3.Cursor, query: str, params: tuple = ()) -> None:
+    """Print the query plan for ``query`` with ``params``."""
+
+    print(query)
+    for row in cursor.execute(f"EXPLAIN QUERY PLAN {query}", params):
+        print(row)
+    print()
+
+
+def main() -> None:
+    db = sqlite3.connect(":memory:")
+    sql_path = Path(__file__).resolve().parent.parent / "database" / "init.sql"
+    db.executescript(sql_path.read_text(encoding="utf-8"))
+
+    # Minimal rows to allow index lookups.
+    db.execute(
+        "INSERT INTO admins(tg_user_id, name, role, permissions_mask) VALUES (?,?,?,?)",
+        (1, "admin", "root", 0),
+    )
+    db.execute(
+        "INSERT INTO subjects(code, name, level_id, term_id) VALUES (?,?,?,?)",
+        ("s", "subject", 1, 1),
+    )
+    db.execute(
+        """
+        INSERT INTO materials(subject_id, section, category, title, url, created_by_admin_id)
+        VALUES (1, 'theory', 'lecture', 't', 'u', 1)
+        """
+    )
+
+    cur = db.cursor()
+    explain(cur, "SELECT * FROM admins WHERE tg_user_id > ?", (0,))
+    explain(cur, "SELECT * FROM subjects WHERE term_id = ?", (1,))
+    explain(
+        cur,
+        "SELECT created_at FROM materials WHERE section = ? ORDER BY created_at",
+        ("theory",),
+    )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- index `admins` by `tg_user_id` for faster lookups
- add composite index on `materials(section, created_at)` to speed retrieval of recent items per section
- include script to show `EXPLAIN QUERY PLAN` output using new indexes

## Testing
- `python scripts/verify_index_usage.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc0c28ec8329bbc2aa10504d565e