### PR TITLE
Prefix navigation callbacks in keyboards and handler

### DIFF
--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -132,6 +132,8 @@ async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     query = update.callback_query
     data = query.data if query else ""
+    if data.startswith("nav:"):
+        data = data[4:]
     stack = NavStack(context.user_data)
 
     if data == "back":

--- a/bot/keyboards/builders/paginated.py
+++ b/bot/keyboards/builders/paginated.py
@@ -41,20 +41,20 @@ def build_children_keyboard(
     keyboard: list[list[InlineKeyboardButton]] = []
     for kind, ident, label in children[start:end]:
         keyboard.append([
-            InlineKeyboardButton(text=label, callback_data=f"{kind}:{ident}")
+            InlineKeyboardButton(text=label, callback_data=f"nav:{kind}:{ident}")
         ])
 
     nav_row: list[InlineKeyboardButton] = []
     if page > 1:
         nav_row.append(
-            InlineKeyboardButton(text="◀", callback_data=f"page:{page - 1}")
+            InlineKeyboardButton(text="◀", callback_data=f"nav:page:{page - 1}")
         )
     if page < pages:
         nav_row.append(
-            InlineKeyboardButton(text="▶", callback_data=f"page:{page + 1}")
+            InlineKeyboardButton(text="▶", callback_data=f"nav:page:{page + 1}")
         )
     if nav_row:
         keyboard.append(nav_row)
 
-    keyboard.append([InlineKeyboardButton(text="🔙", callback_data="back")])
+    keyboard.append([InlineKeyboardButton(text="🔙", callback_data="nav:back")])
     return InlineKeyboardMarkup(keyboard)

--- a/bot/main.py
+++ b/bot/main.py
@@ -78,7 +78,7 @@ def main():
     app.add_handler(approval_callback)
     app.add_handler(duplicate_callback)
     app.add_handler(duplicate_cancel_callback)
-    app.add_handler(CallbackQueryHandler(navtree_callback))
+    app.add_handler(CallbackQueryHandler(navtree_callback, pattern="^nav:"))
     app.add_handler(
         MessageHandler(filters.ALL & filters.ChatType.GROUPS, moderation_handler),
         group=-1,

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -76,7 +76,7 @@ def test_back_button_pops_stack(monkeypatch, navtree):
     stack.push(("level", 1, "L1"))
     stack.push(("term", 2, "T1"))
 
-    query = SimpleNamespace(data="back", message=DummyMessage(), answer=AsyncMock())
+    query = SimpleNamespace(data="nav:back", message=DummyMessage(), answer=AsyncMock())
     update = SimpleNamespace(callback_query=query, effective_user=None)
 
     render_mock = AsyncMock()

--- a/tests/test_paginated_keyboard.py
+++ b/tests/test_paginated_keyboard.py
@@ -9,21 +9,21 @@ def test_build_children_keyboard_first_page():
     children = _make_children(5)
     markup = build_children_keyboard(children, page=1, per_page=2)
     # two items on first page
-    assert markup.inline_keyboard[0][0].callback_data == "kind:1"
-    assert markup.inline_keyboard[1][0].callback_data == "kind:2"
+    assert markup.inline_keyboard[0][0].callback_data == "nav:kind:1"
+    assert markup.inline_keyboard[1][0].callback_data == "nav:kind:2"
     # navigation row should point to next page only
-    assert markup.inline_keyboard[2][0].callback_data == "page:2"
+    assert markup.inline_keyboard[2][0].callback_data == "nav:page:2"
     # back button exists
-    assert markup.inline_keyboard[3][0].callback_data == "back"
+    assert markup.inline_keyboard[3][0].callback_data == "nav:back"
 
 
 def test_build_children_keyboard_middle_page():
     children = _make_children(5)
     markup = build_children_keyboard(children, page=2, per_page=2)
     # items 3 and 4
-    assert markup.inline_keyboard[0][0].callback_data == "kind:3"
-    assert markup.inline_keyboard[1][0].callback_data == "kind:4"
+    assert markup.inline_keyboard[0][0].callback_data == "nav:kind:3"
+    assert markup.inline_keyboard[1][0].callback_data == "nav:kind:4"
     # navigation row has prev and next
-    assert [b.callback_data for b in markup.inline_keyboard[2]] == ["page:1", "page:3"]
+    assert [b.callback_data for b in markup.inline_keyboard[2]] == ["nav:page:1", "nav:page:3"]
     # back button
-    assert markup.inline_keyboard[3][0].callback_data == "back"
+    assert markup.inline_keyboard[3][0].callback_data == "nav:back"


### PR DESCRIPTION
## Summary
- Prefix all navigation callbacks with `nav:` in paginated keyboards and handler logic
- Strip `nav:` prefix in `navtree_callback` and register handler with pattern
- Update tests for new prefixed callback data

## Testing
- `BOT_TOKEN=test ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d903a3508329a88cf43e5404833d