### PR TITLE
Refactor main menu to inline keyboard

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -13,6 +13,7 @@ from .approvals import approvals_handler, approval_callback
 from .moderation import moderation_handler
 from .misc import me_handler, version_handler
 from .navigation_tree import navtree_start, navtree_callback
+from .main_menu import main_menu_callback
 
 __all__ = [
     "start",
@@ -31,4 +32,5 @@ __all__ = [
     "version_handler",
     "navtree_start",
     "navtree_callback",
+    "main_menu_callback",
 ]

--- a/bot/handlers/main_menu.py
+++ b/bot/handlers/main_menu.py
@@ -1,0 +1,32 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .navigation_tree import navtree_start
+from .admins import admins_start
+
+
+async def main_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle presses on the main inline menu."""
+    query = update.callback_query
+    if not query:
+        return
+    data = query.data
+    await query.answer()
+
+    if data == "menu:levels":
+        await navtree_start(update, context)
+    elif data == "menu:plan":
+        await query.edit_message_text("الخطة الدراسية غير متاحة بعد.")
+    elif data == "menu:programs":
+        await query.edit_message_text("البرامج الهندسية غير متاحة بعد.")
+    elif data == "menu:search":
+        await query.edit_message_text("ميزة البحث قيد التطوير.")
+    elif data == "menu:channels":
+        await query.edit_message_text("القنوات والمجموعات ستتوفر قريبًا.")
+    elif data == "menu:help":
+        await query.edit_message_text("للمساعدة يمكنك الرجوع إلى التوثيق أو التواصل مع الدعم.")
+    elif data == "menu:contact":
+        await query.edit_message_text("للتواصل معنا راسل @mechatronics_support.")
+    elif data == "menu:admins":
+        await admins_start(update, context)
+

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -12,6 +12,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     is_admin = False
     if user:
         is_admin = is_owner(user.id) or await has_perm(user.id, MANAGE_ADMINS)
+    # أرسل قائمة البداية باستخدام لوحة أزرار Inline
     await update.message.reply_text(
         "👋 مرحبًا بك في بوت أرشيف قسم الميكاترونكس.\nاختر من القائمة:",
         reply_markup=build_main_menu(is_admin),

--- a/bot/keyboards/builders/main_menu.py
+++ b/bot/keyboards/builders/main_menu.py
@@ -1,8 +1,16 @@
-from telegram import ReplyKeyboardMarkup
+"""Builders for the main menu keyboard.
+
+This module previously returned a ``ReplyKeyboardMarkup`` but it now
+provides an inline keyboard with callback data for every button. Each
+button uses a ``menu:`` prefix so the callback handler can route the
+queries appropriately.
+"""
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 
-def build_main_menu(is_admin: bool = False) -> ReplyKeyboardMarkup:
-    """Return the main menu keyboard.
+def build_main_menu(is_admin: bool = False) -> InlineKeyboardMarkup:
+    """Return the main menu inline keyboard.
 
     Parameters
     ----------
@@ -10,16 +18,30 @@ def build_main_menu(is_admin: bool = False) -> ReplyKeyboardMarkup:
         Whether to include admin-specific options.
     """
     keyboard = [
-        ["📚 المستويات", "🗂 الخطة الدراسية"],
-        ["🔧 البرامج الهندسية", " بحث"],
-        ["📡 القنوات والمجموعات", "🆘 مساعدة"],
-        ["📨 تواصل معنا"],
+        [
+            InlineKeyboardButton(
+                "📚 المستويات", callback_data="menu:levels"
+            ),
+            InlineKeyboardButton(
+                "🗂 الخطة الدراسية", callback_data="menu:plan"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                "🔧 البرامج الهندسية", callback_data="menu:programs"
+            ),
+            InlineKeyboardButton(" بحث", callback_data="menu:search"),
+        ],
+        [
+            InlineKeyboardButton(
+                "📡 القنوات والمجموعات", callback_data="menu:channels"
+            ),
+            InlineKeyboardButton("🆘 مساعدة", callback_data="menu:help"),
+        ],
+        [InlineKeyboardButton("📨 تواصل معنا", callback_data="menu:contact")],
     ]
     if is_admin:
-        keyboard.append(["👤 إدارة المشرفين"])
-    return ReplyKeyboardMarkup(
-        keyboard=keyboard,
-        resize_keyboard=True,
-        one_time_keyboard=True,
-        input_field_placeholder="اختر خيارًا من القائمة  ⬇️",
-    )
+        keyboard.append(
+            [InlineKeyboardButton("👤 إدارة المشرفين", callback_data="menu:admins")]
+        )
+    return InlineKeyboardMarkup(keyboard)

--- a/bot/main.py
+++ b/bot/main.py
@@ -33,6 +33,7 @@ from .handlers import (
     version_handler,
     navtree_start,
     navtree_callback,
+    main_menu_callback,
 )
 from .jobs import purge_temp_archives
 from datetime import time
@@ -78,6 +79,7 @@ def main():
     app.add_handler(approval_callback)
     app.add_handler(duplicate_callback)
     app.add_handler(duplicate_cancel_callback)
+    app.add_handler(CallbackQueryHandler(main_menu_callback, pattern="^menu:"))
     app.add_handler(CallbackQueryHandler(navtree_callback, pattern="^nav:"))
     app.add_handler(
         MessageHandler(filters.ALL & filters.ChatType.GROUPS, moderation_handler),


### PR DESCRIPTION
## Summary
- Replace reply keyboard main menu with inline keyboard and unique callback data
- Handle main menu callbacks including levels navigator and admin management
- Register main menu callback handler in bot initialization

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5db8adfa88329a7ae98e23316cac9