### PR TITLE
Include subject IDs in navigation queries

### DIFF
--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -163,11 +163,15 @@ async def get_terms_by_level(level_id: int):
 
 
 async def get_subjects_by_level_and_term(level_id: int, term_id: int):
-    """Return subject names that have materials for level/term as [(name,), ...]."""
+    """Return subjects with available materials for a level/term.
+
+    The result is a list of ``(id, name)`` pairs ordered by subject id.
+    """
+
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
-            SELECT DISTINCT s.name
+            SELECT DISTINCT s.id, s.name
             FROM subjects s
             JOIN materials m ON m.subject_id = s.id
             WHERE s.level_id = ? AND s.term_id = ?


### PR DESCRIPTION
## Summary
- Return subject IDs along with names in `get_subjects_by_level_and_term`
- Document that the function now yields `(id, name)` pairs

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ec5c896c8329a47eda864fb69f73