### PR TITLE
Add term-level resource options to navigation tree

### DIFF
--- a/bot/db/term_resources.py
+++ b/bot/db/term_resources.py
@@ -1,7 +1,5 @@
 import aiosqlite
-
 from .base import DB_PATH
-
 
 async def insert_term_resource(
     term_id: int,
@@ -20,7 +18,6 @@ async def insert_term_resource(
         await db.commit()
         return cur.lastrowid
 
-
 async def get_latest_term_resource(term_id: int, kind: str):
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
@@ -34,6 +31,13 @@ async def get_latest_term_resource(term_id: int, kind: str):
         )
         return await cur.fetchone()
 
+async def list_term_resource_kinds(term_id: int) -> list[str]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT DISTINCT kind FROM term_resources WHERE term_id=?",
+            (term_id,),
+        )
+        rows = await cur.fetchall()
+        return [row[0] for row in rows]
 
-__all__ = ["insert_term_resource", "get_latest_term_resource"]
-
+__all__ = ["insert_term_resource", "get_latest_term_resource", "list_term_resource_kinds"]

--- a/tests/test_term_options.py
+++ b/tests/test_term_options.py
@@ -1,0 +1,59 @@
+import os
+import asyncio
+from importlib import import_module
+from types import SimpleNamespace
+
+os.environ.setdefault("BOT_TOKEN", "1")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+import pytest
+
+
+@pytest.fixture
+def navtree():
+    return import_module("bot.handlers.navigation_tree")
+
+
+def test_term_without_resources(monkeypatch, navtree):
+    async def _inner():
+        from bot.navigation import tree as tree_module
+
+        async def fake_list_term_resource_kinds(term_id: int):
+            assert term_id == 2
+            return []
+
+        async def fake_can_view(user_id, kind, item_id):
+            return True
+
+        monkeypatch.setattr(tree_module, "list_term_resource_kinds", fake_list_term_resource_kinds)
+        monkeypatch.setattr(tree_module, "can_view", fake_can_view)
+        tree_module.invalidate()
+
+        ctx = SimpleNamespace(user_data={})
+        children = await navtree._load_children(ctx, "term", (1, 2), user_id=1)
+        assert children == [("term_option", "subjects", "عرض المواد")]
+
+    asyncio.run(_inner())
+
+
+def test_term_with_resources(monkeypatch, navtree):
+    async def _inner():
+        from bot.navigation import tree as tree_module
+
+        async def fake_list_term_resource_kinds(term_id: int):
+            return ["attendance"]
+
+        async def fake_can_view(user_id, kind, item_id):
+            return True
+
+        monkeypatch.setattr(tree_module, "list_term_resource_kinds", fake_list_term_resource_kinds)
+        monkeypatch.setattr(tree_module, "can_view", fake_can_view)
+        tree_module.invalidate()
+
+        ctx = SimpleNamespace(user_data={})
+        children = await navtree._load_children(ctx, "term", (1, 2), user_id=1)
+        assert ("term_option", "subjects", "عرض المواد") in children
+        assert ("term_option", "attendance", "جدول الحضور") in children
+
+    asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- Support term menu options including resources and subject listing
- Handle term option callbacks to deliver latest term resources
- Add database helper and tests for term menu option rendering

## Testing
- `BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fdef0a6883299ab5db53c35fb7ae