### PR TITLE
Add strict term resource kinds with tests

### DIFF
--- a/database/init.sql
+++ b/database/init.sql
@@ -172,12 +172,40 @@ ON materials(section, created_at);
 CREATE TABLE IF NOT EXISTS term_resources (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     term_id INTEGER NOT NULL,
-    kind TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK(kind IN (
+        'attendance','study_plan','channels','outcomes','tips',
+        'projects','programs','apps','skills','forums','sites'
+    )),
     tg_storage_chat_id INTEGER NOT NULL,
     tg_storage_msg_id INTEGER NOT NULL,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (term_id) REFERENCES terms(id)
 );
+
+-- ترحيل البيانات القديمة لإضافة القيد على نوع المورد
+-- BEGIN TRANSACTION;
+-- ALTER TABLE term_resources RENAME TO term_resources_old;
+-- CREATE TABLE term_resources (
+--     id INTEGER PRIMARY KEY AUTOINCREMENT,
+--     term_id INTEGER NOT NULL,
+--     kind TEXT NOT NULL CHECK(kind IN (
+--         'attendance','study_plan','channels','outcomes','tips',
+--         'projects','programs','apps','skills','forums','sites'
+--     )),
+--     tg_storage_chat_id INTEGER NOT NULL,
+--     tg_storage_msg_id INTEGER NOT NULL,
+--     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+--     FOREIGN KEY (term_id) REFERENCES terms(id)
+-- );
+-- INSERT INTO term_resources(id, term_id, kind, tg_storage_chat_id, tg_storage_msg_id, created_at)
+-- SELECT id, term_id, kind, tg_storage_chat_id, tg_storage_msg_id, created_at
+-- FROM term_resources_old
+-- WHERE kind IN (
+--     'attendance','study_plan','channels','outcomes','tips',
+--     'projects','programs','apps','skills','forums','sites'
+-- );
+-- DROP TABLE term_resources_old;
+-- COMMIT;
 
 CREATE INDEX IF NOT EXISTS idx_term_resources_term_kind
 ON term_resources(term_id, kind);

--- a/tests/test_term_resources.py
+++ b/tests/test_term_resources.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import aiosqlite
+
+os.environ.setdefault("BOT_TOKEN", "1")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+from bot.db import base as db_base
+from bot.db import term_resources
+
+
+def test_term_resource_kinds(tmp_path):
+    async def _inner():
+        db_path = tmp_path / "test.db"
+        db_base.DB_PATH = term_resources.DB_PATH = str(db_path)
+        await db_base.init_db()
+        async with aiosqlite.connect(db_base.DB_PATH) as db:
+            await db.execute("INSERT INTO terms (name) VALUES ('T1')")
+            await db.commit()
+
+        for i, kind in enumerate(term_resources.TermResourceKind):
+            await term_resources.insert_term_resource(1, kind, 100 + i, 200 + i)
+            assert await term_resources.has_term_resource(1, kind)
+            chat_id, msg_id = await term_resources.get_latest_term_resource(1, kind)
+            assert (chat_id, msg_id) == (100 + i, 200 + i)
+
+        kinds = await term_resources.list_term_resource_kinds(1)
+        assert set(kinds) == {k.value for k in term_resources.TermResourceKind}
+
+    asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- enforce explicit set of allowed term resource kinds in database
- add `TermResourceKind` enum with validation and `has_term_resource` helper
- test inserting and retrieving all term resource kinds

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6001afcfc83299088b7fbb863fc77