### PR TITLE
test term resource hashtag aliases

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,20 @@
+"""Shared helpers for test modules.
+
+This module exposes :data:`TERM_RESOURCE_TAGS` which mirrors the
+``TERM_RESOURCE_ALIASES`` mapping from ``bot.parser.hashtags`` but prefixes
+each alias with ``#``.  Keeping the mapping in a single place ensures tests
+remain in sync with the parser whenever new term resource tags are added.
+"""
+
+from __future__ import annotations
+
+from bot.parser.hashtags import TERM_RESOURCE_ALIASES
+
+
+# Map each term resource ``kind`` to the four accepted hashtag variants
+# prefixed with ``#`` as they would appear in messages.
+TERM_RESOURCE_TAGS = {
+    kind: tuple(f"#{alias}" for alias in aliases)
+    for kind, aliases in TERM_RESOURCE_ALIASES.items()
+}
+

--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -1,6 +1,7 @@
 import pytest
 
-from bot.parser.hashtags import parse_hashtags, TERM_RESOURCE_ALIASES
+from bot.parser.hashtags import parse_hashtags
+from tests.helpers import TERM_RESOURCE_TAGS
 
 
 def test_parse_hashtags_accepts_full_lecture_sequence():
@@ -21,15 +22,11 @@ def test_parse_hashtags_accepts_full_lecture_sequence():
     assert info.lecturer == "فلان"
 
 
-@pytest.mark.parametrize(
-    "tag, expected",
-    [
-        (f"#{alias}", kind)
-        for kind, aliases in TERM_RESOURCE_ALIASES.items()
-        for alias in aliases
-    ],
-)
-def test_parse_hashtags_term_resources(tag, expected):
-    info, error = parse_hashtags(tag)
-    assert error is None
-    assert info.content_type == expected
+@pytest.mark.parametrize("kind, tags", TERM_RESOURCE_TAGS.items())
+def test_parse_hashtags_term_resources(kind, tags):
+    results = []
+    for tag in tags:
+        info, error = parse_hashtags(tag)
+        assert error is None
+        results.append(info.content_type)
+    assert set(results) == {kind}


### PR DESCRIPTION
## Summary
- Share `TERM_RESOURCE_TAGS` helper based on parser aliases so tests stay in sync
- Parameterize hashtag parsing tests over each category's four aliases
- Verify term resource ingestion handles every alias and records the correct kind

## Testing
- `PYTHONPATH=. pytest tests/test_hashtags.py tests/test_term_resource_ingestion.py`


------
https://chatgpt.com/codex/tasks/task_e_68b608dcedd48329b6ae9744445cc73c