### PR TITLE
Auto-register groups for term resources

### DIFF
--- a/tests/test_term_resource_ingestion.py
+++ b/tests/test_term_resource_ingestion.py
@@ -61,3 +61,54 @@ async def test_term_resource_ingestion(kind, tags, monkeypatch):
         await ingestion.ingestion_handler(update, context)
 
         assert calls == [(1, kind, 111, 222)]
+
+
+async def test_term_resource_unknown_chat_autoregisters(monkeypatch):
+    calls = []
+    upserts = []
+
+    async def fake_insert_term_resource(term_id, k, chat_id, msg_id):
+        calls.append((term_id, k, chat_id, msg_id))
+
+    async def fake_get_admin_with_permissions(user_id):
+        return (1, ingestion.UPLOAD_CONTENT)
+
+    async def fake_get_group_id_by_chat(chat_id):
+        return None
+
+    async def fake_upsert_group(chat_id, level_id, term_id, title):
+        upserts.append((chat_id, level_id, term_id, title))
+
+    async def fake_send_ephemeral(*args, **kwargs):
+        return None
+
+    def fake_get_file_unique_id_from_message(message):
+        return None
+
+    monkeypatch.setattr(ingestion, "insert_term_resource", fake_insert_term_resource)
+    monkeypatch.setattr(ingestion, "get_admin_with_permissions", fake_get_admin_with_permissions)
+    monkeypatch.setattr(ingestion, "get_group_id_by_chat", fake_get_group_id_by_chat)
+    monkeypatch.setattr(ingestion, "upsert_group", fake_upsert_group)
+    monkeypatch.setattr(ingestion, "send_ephemeral", fake_send_ephemeral)
+    monkeypatch.setattr(
+        ingestion, "get_file_unique_id_from_message", fake_get_file_unique_id_from_message
+    )
+
+    message = SimpleNamespace(
+        caption=None,
+        text="#attendance",
+        chat_id=111,
+        message_id=222,
+        message_thread_id=None,
+    )
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_chat=SimpleNamespace(id=111, title="test"),
+        effective_user=SimpleNamespace(id=42),
+    )
+    context = SimpleNamespace(user_data={})
+
+    await ingestion.ingestion_handler(update, context)
+
+    assert upserts == [(111, 1, 1, "test")]
+    assert calls == [(1, "attendance", 111, 222)]


### PR DESCRIPTION
## Summary
- Auto-register unknown chats when receiving term resources and note the registration
- Warn and continue ingesting term resources for newly registered groups
- Test auto-registration behavior when chat is initially unknown

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b60a1f2fd083299c6d602e3642b74c