### PR TITLE
Scope term resources by level

### DIFF
--- a/bot/db/term_resources.py
+++ b/bot/db/term_resources.py
@@ -27,6 +27,7 @@ def _validate_kind(kind: str | TermResourceKind) -> str:
         raise ValueError(f"Unsupported term resource kind: {kind}") from exc
 
 async def insert_term_resource(
+    level_id: int,
     term_id: int,
     kind: str | TermResourceKind,
     storage_chat_id: int,
@@ -36,43 +37,45 @@ async def insert_term_resource(
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
-            INSERT INTO term_resources (term_id, kind, tg_storage_chat_id, tg_storage_msg_id)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO term_resources (level_id, term_id, kind, tg_storage_chat_id, tg_storage_msg_id)
+            VALUES (?, ?, ?, ?, ?)
             """,
-            (term_id, kind_val, storage_chat_id, storage_msg_id),
+            (level_id, term_id, kind_val, storage_chat_id, storage_msg_id),
         )
         await db.commit()
         return cur.lastrowid
 
-async def get_latest_term_resource(term_id: int, kind: str | TermResourceKind):
+async def get_latest_term_resource(
+    level_id: int, term_id: int, kind: str | TermResourceKind
+):
     kind_val = _validate_kind(kind)
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
             SELECT tg_storage_chat_id, tg_storage_msg_id
             FROM term_resources
-            WHERE term_id=? AND kind=?
+            WHERE level_id=? AND term_id=? AND kind=?
             ORDER BY id DESC LIMIT 1
             """,
-            (term_id, kind_val),
+            (level_id, term_id, kind_val),
         )
         return await cur.fetchone()
 
 
-async def has_term_resource(term_id: int, kind: str | TermResourceKind) -> bool:
+async def has_term_resource(level_id: int, term_id: int, kind: str | TermResourceKind) -> bool:
     kind_val = _validate_kind(kind)
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
-            "SELECT 1 FROM term_resources WHERE term_id=? AND kind=? LIMIT 1",
-            (term_id, kind_val),
+            "SELECT 1 FROM term_resources WHERE level_id=? AND term_id=? AND kind=? LIMIT 1",
+            (level_id, term_id, kind_val),
         )
         return await cur.fetchone() is not None
 
-async def list_term_resource_kinds(term_id: int) -> list[str]:
+async def list_term_resource_kinds(level_id: int, term_id: int) -> list[str]:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
-            "SELECT DISTINCT kind FROM term_resources WHERE term_id=?",
-            (term_id,),
+            "SELECT DISTINCT kind FROM term_resources WHERE level_id=? AND term_id=?",
+            (level_id, term_id),
         )
         rows = await cur.fetchall()
         return [row[0] for row in rows]

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -193,8 +193,9 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         return
 
     if category in TERM_RESOURCE_TYPES:
+        level_id = group_info[1]
         term_id = group_info[2]
-        await insert_term_resource(term_id, category, chat.id, message.message_id)
+        await insert_term_resource(level_id, term_id, category, chat.id, message.message_id)
         confirmation = "✅ تم الاستلام."
         if auto_registered:
             confirmation += " تم تسجيل المجموعة تلقائيًا."

--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -221,9 +221,11 @@ async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 break
         if kind == "term_option":
             if ident_str != "subjects":
-                term_id = parent_id[1] if isinstance(parent_id, tuple) else parent_id
+                level_id, term_id = (
+                    parent_id if isinstance(parent_id, tuple) else (None, parent_id)
+                )
                 try:
-                    res = await get_latest_term_resource(term_id, ident_str)
+                    res = await get_latest_term_resource(level_id, term_id, ident_str)
                     if res:
                         chat_id, msg_id = res
                         target_chat = query.message.chat_id if query else update.effective_chat.id

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -33,9 +33,9 @@ TERM_RESOURCE_LABELS = {
     "study_plan": "الخطة الدراسية",
 }
 
-async def get_term_menu_items(_level_id: int, term_id: int):
+async def get_term_menu_items(level_id: int, term_id: int):
     items = [("subjects", "عرض المواد")]
-    kinds = await list_term_resource_kinds(term_id)
+    kinds = await list_term_resource_kinds(level_id, term_id)
     for kind in kinds:
         label = TERM_RESOURCE_LABELS.get(kind, kind)
         items.append((kind, label))

--- a/database/init.sql
+++ b/database/init.sql
@@ -171,6 +171,7 @@ ON materials(section, created_at);
 -- موارد مرتبطة بالترم (مثل جدول الحضور)
 CREATE TABLE IF NOT EXISTS term_resources (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    level_id INTEGER NOT NULL,
     term_id INTEGER NOT NULL,
     kind TEXT NOT NULL CHECK(kind IN (
         'attendance','study_plan','channels','outcomes','tips',
@@ -179,6 +180,7 @@ CREATE TABLE IF NOT EXISTS term_resources (
     tg_storage_chat_id INTEGER NOT NULL,
     tg_storage_msg_id INTEGER NOT NULL,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (level_id) REFERENCES levels(id),
     FOREIGN KEY (term_id) REFERENCES terms(id)
 );
 
@@ -207,5 +209,5 @@ CREATE TABLE IF NOT EXISTS term_resources (
 -- DROP TABLE term_resources_old;
 -- COMMIT;
 
-CREATE INDEX IF NOT EXISTS idx_term_resources_term_kind
-ON term_resources(term_id, kind);
+CREATE INDEX IF NOT EXISTS idx_term_resources_level_term_kind
+ON term_resources(level_id, term_id, kind);

--- a/database/migrate_term_resources_level.sql
+++ b/database/migrate_term_resources_level.sql
@@ -1,0 +1,31 @@
+BEGIN TRANSACTION;
+ALTER TABLE term_resources RENAME TO term_resources_old;
+CREATE TABLE term_resources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    level_id INTEGER NOT NULL,
+    term_id INTEGER NOT NULL,
+    kind TEXT NOT NULL CHECK(kind IN (
+        'attendance','study_plan','channels','outcomes','tips',
+        'projects','programs','apps','skills','forums','sites'
+    )),
+    tg_storage_chat_id INTEGER NOT NULL,
+    tg_storage_msg_id INTEGER NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (level_id) REFERENCES levels(id),
+    FOREIGN KEY (term_id) REFERENCES terms(id)
+);
+INSERT INTO term_resources (id, level_id, term_id, kind, tg_storage_chat_id, tg_storage_msg_id, created_at)
+SELECT
+    tr.id,
+    COALESCE((SELECT level_id FROM groups WHERE term_id = tr.term_id AND level_id IS NOT NULL LIMIT 1), 1),
+    tr.term_id,
+    tr.kind,
+    tr.tg_storage_chat_id,
+    tr.tg_storage_msg_id,
+    tr.created_at
+FROM term_resources_old tr;
+DROP TABLE term_resources_old;
+DROP INDEX IF EXISTS idx_term_resources_term_kind;
+CREATE INDEX idx_term_resources_level_term_kind
+    ON term_resources(level_id, term_id, kind);
+COMMIT;

--- a/tests/test_term_options.py
+++ b/tests/test_term_options.py
@@ -19,8 +19,8 @@ def test_term_without_resources(monkeypatch, navtree):
     async def _inner():
         from bot.navigation import tree as tree_module
 
-        async def fake_list_term_resource_kinds(term_id: int):
-            assert term_id == 2
+        async def fake_list_term_resource_kinds(level_id: int, term_id: int):
+            assert (level_id, term_id) == (1, 2)
             return []
 
         async def fake_can_view(user_id, kind, item_id):
@@ -41,7 +41,8 @@ def test_term_with_resources(monkeypatch, navtree):
     async def _inner():
         from bot.navigation import tree as tree_module
 
-        async def fake_list_term_resource_kinds(term_id: int):
+        async def fake_list_term_resource_kinds(level_id: int, term_id: int):
+            assert (level_id, term_id) == (1, 2)
             return ["attendance"]
 
         async def fake_can_view(user_id, kind, item_id):

--- a/tests/test_term_resource_ingestion.py
+++ b/tests/test_term_resource_ingestion.py
@@ -21,14 +21,14 @@ def anyio_backend():
 async def test_term_resource_ingestion(kind, tags, monkeypatch):
     calls = []
 
-    async def fake_insert_term_resource(term_id, k, chat_id, msg_id):
-        calls.append((term_id, k, chat_id, msg_id))
+    async def fake_insert_term_resource(level_id, term_id, k, chat_id, msg_id):
+        calls.append((level_id, term_id, k, chat_id, msg_id))
 
     async def fake_get_admin_with_permissions(user_id):
         return (1, ingestion.UPLOAD_CONTENT)
 
     async def fake_get_group_id_by_chat(chat_id):
-        return (None, None, 1)
+        return (None, 1, 1)
 
     async def fake_send_ephemeral(*args, **kwargs):
         return None
@@ -60,15 +60,15 @@ async def test_term_resource_ingestion(kind, tags, monkeypatch):
 
         await ingestion.ingestion_handler(update, context)
 
-        assert calls == [(1, kind, 111, 222)]
+        assert calls == [(1, 1, kind, 111, 222)]
 
 
 async def test_term_resource_unknown_chat_autoregisters(monkeypatch):
     calls = []
     upserts = []
 
-    async def fake_insert_term_resource(term_id, k, chat_id, msg_id):
-        calls.append((term_id, k, chat_id, msg_id))
+    async def fake_insert_term_resource(level_id, term_id, k, chat_id, msg_id):
+        calls.append((level_id, term_id, k, chat_id, msg_id))
 
     async def fake_get_admin_with_permissions(user_id):
         return (1, ingestion.UPLOAD_CONTENT)
@@ -111,4 +111,4 @@ async def test_term_resource_unknown_chat_autoregisters(monkeypatch):
     await ingestion.ingestion_handler(update, context)
 
     assert upserts == [(111, 1, 1, "test")]
-    assert calls == [(1, "attendance", 111, 222)]
+    assert calls == [(1, 1, "attendance", 111, 222)]

--- a/tests/test_term_resources.py
+++ b/tests/test_term_resources.py
@@ -12,20 +12,26 @@ from bot.db import term_resources
 
 def test_term_resource_kinds(tmp_path):
     async def _inner():
-        db_path = tmp_path / "test.db"
-        db_base.DB_PATH = term_resources.DB_PATH = str(db_path)
-        await db_base.init_db()
-        async with aiosqlite.connect(db_base.DB_PATH) as db:
-            await db.execute("INSERT INTO terms (name) VALUES ('T1')")
-            await db.commit()
+          db_path = tmp_path / "test.db"
+          db_base.DB_PATH = term_resources.DB_PATH = str(db_path)
+          await db_base.init_db()
+          async with aiosqlite.connect(db_base.DB_PATH) as db:
+              await db.execute("INSERT INTO levels (name) VALUES ('L1'),('L2')")
+              await db.execute("INSERT INTO terms (name) VALUES ('T1')")
+              await db.commit()
 
-        for i, kind in enumerate(term_resources.TermResourceKind):
-            await term_resources.insert_term_resource(1, kind, 100 + i, 200 + i)
-            assert await term_resources.has_term_resource(1, kind)
-            chat_id, msg_id = await term_resources.get_latest_term_resource(1, kind)
-            assert (chat_id, msg_id) == (100 + i, 200 + i)
+          for i, kind in enumerate(term_resources.TermResourceKind):
+              await term_resources.insert_term_resource(1, 1, kind, 100 + i, 200 + i)
+              assert await term_resources.has_term_resource(1, 1, kind)
+              chat_id, msg_id = await term_resources.get_latest_term_resource(1, 1, kind)
+              assert (chat_id, msg_id) == (100 + i, 200 + i)
 
-        kinds = await term_resources.list_term_resource_kinds(1)
-        assert set(kinds) == {k.value for k in term_resources.TermResourceKind}
+          assert not await term_resources.has_term_resource(
+              2, 1, term_resources.TermResourceKind.ATTENDANCE
+          )
+          assert await term_resources.list_term_resource_kinds(2, 1) == []
+
+          kinds = await term_resources.list_term_resource_kinds(1, 1)
+          assert set(kinds) == {k.value for k in term_resources.TermResourceKind}
 
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- Add level_id to term_resources table and index
- Scope term resource CRUD to level and term
- Pass level when ingesting and navigating term resources

## Testing
- `python3 -m py_compile bot/db/term_resources.py bot/handlers/ingestion.py bot/navigation/tree.py bot/handlers/navigation_tree.py bot/db/base.py tests/test_term_resources.py tests/test_term_options.py tests/test_term_resource_ingestion.py`
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d8ab2748329a365b41b08864956