### PR TITLE
refactor: migrate term resources index

### DIFF
--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -140,15 +140,16 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         await db.execute(
             "UPDATE term_resources SET level_id = 1 WHERE level_id IS NULL"
         )
-        await db.execute(
-            "DROP INDEX IF EXISTS idx_term_resources_term_kind"
-        )
-        await db.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_term_resources_level_term_kind
-            ON term_resources(level_id, term_id, kind)
-            """
-        )
+
+    await db.execute(
+        "DROP INDEX IF EXISTS idx_term_resources_term_kind"
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_term_resources_level_term_kind
+        ON term_resources(level_id, term_id, kind)
+        """
+    )
 
     # indexes
     await db.execute(

--- a/database/init.sql
+++ b/database/init.sql
@@ -209,5 +209,6 @@ CREATE TABLE IF NOT EXISTS term_resources (
 -- DROP TABLE term_resources_old;
 -- COMMIT;
 
-CREATE INDEX IF NOT EXISTS idx_term_resources_level_term_kind
-ON term_resources(level_id, term_id, kind);
+-- Removed index creation; handled in migration
+-- CREATE INDEX IF NOT EXISTS idx_term_resources_level_term_kind
+-- ON term_resources(level_id, term_id, kind);


### PR DESCRIPTION
## Summary
- remove inline term_resources index from init SQL
- always ensure level-based index via migration

## Testing
- `PYTHONPATH=. BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6121bd9248329b9769c2811cc721a