### PR TITLE
Add Arabic emoji labels for term resources

### DIFF
--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -29,8 +29,17 @@ CACHE_TTL_SECONDS = 90  # within the 60-120 second range requested
 _cache: Dict[Tuple[int | None, str, Tuple[Any, ...]], Tuple[float, Any]] = {}
 
 TERM_RESOURCE_LABELS = {
-    "attendance": "جدول الحضور",
-    "study_plan": "الخطة الدراسية",
+    "attendance": "جدول الحضور 🗓️",
+    "study_plan": "الخطة الدراسية 📖",
+    "channels": "روابط القنوات 📎",
+    "outcomes": "مخرجات التعلم 🎯",
+    "tips": "نصائح دراسية 💡",
+    "projects": "أفكار المشاريع 🛠️",
+    "programs": "برامج مقترحة 🖥️",
+    "apps": "تطبيقات مفيدة 📱",
+    "skills": "مهارات مطلوبة 🧠",
+    "forums": "منتديات للنقاش 💬",
+    "sites": "مواقع إلكترونية 🌐",
 }
 
 async def get_term_menu_items(level_id: int, term_id: int):

--- a/tests/test_term_options.py
+++ b/tests/test_term_options.py
@@ -55,6 +55,6 @@ def test_term_with_resources(monkeypatch, navtree):
         ctx = SimpleNamespace(user_data={})
         children = await navtree._load_children(ctx, "term", (1, 2), user_id=1)
         assert ("term_option", "subjects", "عرض المواد") in children
-        assert ("term_option", "attendance", "جدول الحضور") in children
+        assert ("term_option", "attendance", "جدول الحضور 🗓️") in children
 
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- localize all term resource labels with Arabic text and emojis
- update term options test for new attendance label

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b61862011c83299d646677f763f82b