### PR TITLE
Add row width option for paginated keyboards

### DIFF
--- a/bot/keyboards/builders/paginated.py
+++ b/bot/keyboards/builders/paginated.py
@@ -13,6 +13,7 @@ def build_children_keyboard(
     page: int,
     per_page: int | None = None,
     include_back: bool = True,
+    row_width: int = 2,
 ) -> InlineKeyboardMarkup:
     """Build a paginated inline keyboard for navigation children.
 
@@ -27,6 +28,8 @@ def build_children_keyboard(
         :data:`PER_PAGE` configuration value when ``None``.
     include_back:
         Whether to include a "back" button at the bottom of the keyboard.
+    row_width:
+        Maximum number of child buttons to display in each row.
     """
 
     if per_page is None:
@@ -41,11 +44,20 @@ def build_children_keyboard(
     start = (page - 1) * per_page
     end = start + per_page
 
+    if row_width <= 0:
+        row_width = 1
+
     keyboard: list[list[InlineKeyboardButton]] = []
-    for kind, ident, label in children[start:end]:
-        keyboard.append([
+    row: list[InlineKeyboardButton] = []
+    for idx, (kind, ident, label) in enumerate(children[start:end], start=1):
+        row.append(
             InlineKeyboardButton(text=label, callback_data=f"nav:{kind}:{ident}")
-        ])
+        )
+        if idx % row_width == 0:
+            keyboard.append(row)
+            row = []
+    if row:
+        keyboard.append(row)
 
     nav_row: list[InlineKeyboardButton] = []
     if page > 1:

--- a/tests/test_paginated_keyboard.py
+++ b/tests/test_paginated_keyboard.py
@@ -10,11 +10,11 @@ def test_build_children_keyboard_first_page():
     markup = build_children_keyboard(children, page=1, per_page=2)
     # two items on first page
     assert markup.inline_keyboard[0][0].callback_data == "nav:kind:1"
-    assert markup.inline_keyboard[1][0].callback_data == "nav:kind:2"
+    assert markup.inline_keyboard[0][1].callback_data == "nav:kind:2"
     # navigation row should point to next page only
-    assert markup.inline_keyboard[2][0].callback_data == "nav:page:2"
+    assert markup.inline_keyboard[1][0].callback_data == "nav:page:2"
     # back button exists
-    assert markup.inline_keyboard[3][0].callback_data == "nav:back"
+    assert markup.inline_keyboard[2][0].callback_data == "nav:back"
 
 
 def test_build_children_keyboard_middle_page():
@@ -22,8 +22,8 @@ def test_build_children_keyboard_middle_page():
     markup = build_children_keyboard(children, page=2, per_page=2)
     # items 3 and 4
     assert markup.inline_keyboard[0][0].callback_data == "nav:kind:3"
-    assert markup.inline_keyboard[1][0].callback_data == "nav:kind:4"
+    assert markup.inline_keyboard[0][1].callback_data == "nav:kind:4"
     # navigation row has prev and next
-    assert [b.callback_data for b in markup.inline_keyboard[2]] == ["nav:page:1", "nav:page:3"]
+    assert [b.callback_data for b in markup.inline_keyboard[1]] == ["nav:page:1", "nav:page:3"]
     # back button
-    assert markup.inline_keyboard[3][0].callback_data == "nav:back"
+    assert markup.inline_keyboard[2][0].callback_data == "nav:back"


### PR DESCRIPTION
## Summary
- allow configuring `row_width` when building paginated keyboards, default 2 per row
- adjust pagination tests for grouped button rows

## Testing
- `BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 PYTHONPATH=. pytest tests/test_paginated_keyboard.py -q`
- `BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61905408c8329b0b1f1ee91814136