### PR TITLE
Filter available sections to core education types

### DIFF
--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -257,7 +257,9 @@ async def get_available_sections_for_subject(subject_id: int) -> list[str]:
             """
             SELECT DISTINCT section
             FROM materials
-            WHERE subject_id=? AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
+            WHERE subject_id=?
+              AND section IN ('theory','discussion','lab','field_trip')
+              AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
             """,
             (subject_id,),
         )


### PR DESCRIPTION
## Summary
- Restrict `get_available_sections_for_subject` to return only core sections (`theory`, `discussion`, `lab`, `field_trip`)
- Ensure navigation tests confirm skipping the section layer when only one section exists

## Testing
- `PYTHONPATH=. pytest tests/test_navigation_tree.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62b8071208329849510786519c426