### PR TITLE
Add field trip section

### DIFF
--- a/bot/handlers/topics.py
+++ b/bot/handlers/topics.py
@@ -32,15 +32,17 @@ SECTION_ALIASES = {
     "مناقشة": "discussion",
     "مناقشه": "discussion",
     "عملي": "lab",
+    "رحلة": "field_trip",
 }
 
 SECTION_LABELS = {
     "theory": "نظري",
     "discussion": "مناقشة",
     "lab": "عملي",
+    "field_trip": "رحلة",
 }
 
-FULL_RE = re.compile(r"^(?P<subject>[^-]+?)\s*-\s*(?P<section>نظري|عملي|مناقشة)\s*$")
+FULL_RE = re.compile(r"^(?P<subject>[^-]+?)\s*-\s*(?P<section>نظري|عملي|مناقشة|مناقشه|رحلة)\s*$")
 NAME_RE = re.compile(r"^(?P<subject>.+?)\s*$")
 
 

--- a/database/init.sql
+++ b/database/init.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS topics (
     group_id INTEGER NOT NULL,
     tg_topic_id INTEGER NOT NULL,
     subject_id INTEGER NOT NULL,
-    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab')),
+    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','field_trip')),
     FOREIGN KEY (group_id) REFERENCES groups(id),
     FOREIGN KEY (subject_id) REFERENCES subjects(id),
     UNIQUE (group_id, tg_topic_id)
@@ -129,7 +129,7 @@ ON ingestions(admin_id);
 CREATE TABLE IF NOT EXISTS materials (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     subject_id INTEGER NOT NULL,
-    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','syllabus','apps')),
+    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','field_trip','syllabus','apps')),
     category TEXT NOT NULL CHECK(category IN (
     'lecture','slides','audio','exam','booklet','board_images','video','simulation',
     'summary','notes','external_link','mind_map','transcript','related'

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -197,6 +197,7 @@ def test_parse_id_handles_composite(navtree):
     assert navtree._parse_id("abc") == "abc"
     assert navtree._parse_id("1-2") == (1, 2)
     assert navtree._parse_id("123-theory") == (123, "theory")
+    assert navtree._parse_id("123-field_trip") == (123, "field_trip")
 
 
 def test_load_children_merges_level_and_term(monkeypatch, navtree):
@@ -220,7 +221,7 @@ def test_load_children_merges_subject_and_section(monkeypatch, navtree):
     async def fake_get_children(kind, ident, user_id):
         assert kind == "subject"
         assert ident == 7
-        return ["theory", "lab"]
+        return ["theory", "lab", "field_trip"]
 
     monkeypatch.setattr(navtree, "get_children", fake_get_children)
 
@@ -233,6 +234,7 @@ def test_load_children_merges_subject_and_section(monkeypatch, navtree):
     assert children == [
         ("section", "7-theory", "theory"),
         ("section", "7-lab", "lab"),
+        ("section", "7-field_trip", "field_trip"),
     ]
 
 


### PR DESCRIPTION
## Summary
- allow field trip section in topics and materials schema
- support field trip binding in topic handlers
- include field trip in navigation tests and DB migration

## Testing
- `BOT_TOKEN=1 ARCHIVE_CHANNEL_ID=1 OWNER_TG_ID=1 python - <<'PY'
import asyncio
from bot.db.base import init_db, migrate_if_needed
asyncio.run(init_db())
asyncio.run(migrate_if_needed())
PY`
- `sqlite3 database/archive.db "SELECT sql FROM sqlite_master WHERE type='table' AND name='topics';"`
- `sqlite3 database/archive.db "SELECT sql FROM sqlite_master WHERE type='table' AND name='materials';"`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b62c85044c8329960d4c4a7e781fff