### PR TITLE
Add Arabic section labels for navigation tree

### DIFF
--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -22,6 +22,16 @@ logger = logging.getLogger(__name__)
 LAST_CHILDREN_KEY = "last_children"
 LAST_CHILDREN_TTL_SECONDS = CACHE_TTL_SECONDS
 
+# Arabic labels with icons for subject sections
+SECTION_LABELS = {
+    "theory": "نظري 📘",
+    "discussion": "مناقشة 💬",
+    "lab": "عملي 🔬",
+    "field_trip": "رحلة 🚌",
+    "syllabus": "التوصيف 📄",
+    "apps": "تطبيقات مفيدة 📱",
+}
+
 
 async def _load_children(
     context: ContextTypes.DEFAULT_TYPE,
@@ -55,6 +65,8 @@ async def _load_children(
             item_id = f"{ident}-{item_id}"
         elif kind == "subject" and child_kind == "section":
             item_id = f"{ident}-{item_id}"
+        if child_kind == "section":
+            item_label = SECTION_LABELS.get(item_label, item_label)
         children.append((child_kind, item_id, item_label))
     context.user_data[LAST_CHILDREN_KEY] = {
         "node_key": node_key,

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -232,10 +232,38 @@ def test_load_children_merges_subject_and_section(monkeypatch, navtree):
 
     children = asyncio.run(run())
     assert children == [
-        ("section", "7-theory", "theory"),
-        ("section", "7-lab", "lab"),
-        ("section", "7-field_trip", "field_trip"),
+        ("section", "7-theory", "نظري 📘"),
+        ("section", "7-lab", "عملي 🔬"),
+        ("section", "7-field_trip", "رحلة 🚌"),
     ]
+
+
+@pytest.mark.parametrize(
+    "section,label",
+    [
+        ("theory", "نظري 📘"),
+        ("discussion", "مناقشة 💬"),
+        ("lab", "عملي 🔬"),
+        ("field_trip", "رحلة 🚌"),
+        ("syllabus", "التوصيف 📄"),
+        ("apps", "تطبيقات مفيدة 📱"),
+    ],
+)
+def test_section_label_translation(monkeypatch, navtree, section, label):
+    async def fake_get_children(kind, ident, user_id):
+        assert kind == "subject"
+        assert ident == 7
+        return [section]
+
+    monkeypatch.setattr(navtree, "get_children", fake_get_children)
+
+    ctx = SimpleNamespace(user_data={})
+
+    async def run():
+        return await navtree._load_children(ctx, "subject", 7, user_id=None)
+
+    children = asyncio.run(run())
+    assert children == [("section", f"7-{section}", label)]
 
 
 def test_get_children_accepts_composite(monkeypatch):


### PR DESCRIPTION
## Summary
- translate subject section codes to Arabic with icons via SECTION_LABELS
- apply translation in _load_children
- test section label translations including syllabus

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63390e0f483298e3769ada9c9a319