### PR TITLE
Support additional material sections

### DIFF
--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -132,7 +132,7 @@ async def _migrate(db: aiosqlite.Connection) -> None:
         if not await _column_exists(db, "ingestions", col):
             await db.execute(f"ALTER TABLE ingestions ADD COLUMN {col} {col_type}")
 
-    # ensure section constraints allow field_trip
+    # ensure section constraints allow additional sections
     if not await _table_has_text(db, "topics", "'field_trip'"):
         await db.executescript(
             """
@@ -153,14 +153,17 @@ async def _migrate(db: aiosqlite.Connection) -> None:
             """
         )
 
-    if not await _table_has_text(db, "materials", "'field_trip'"):
+    if not await _table_has_text(db, "materials", "'open_source_projects'"):
         await db.executescript(
             """
             ALTER TABLE materials RENAME TO materials_old;
             CREATE TABLE materials (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 subject_id INTEGER NOT NULL,
-                section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','field_trip','syllabus','apps')),
+                section TEXT NOT NULL CHECK(section IN (
+                    'theory','discussion','lab','field_trip','syllabus','apps',
+                    'vocabulary','references','skills','open_source_projects'
+                )),
                 category TEXT NOT NULL CHECK(category IN (
                     'lecture','slides','audio','exam','booklet','board_images','video','simulation',
                     'summary','notes','external_link','mind_map','transcript','related'

--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -258,7 +258,10 @@ async def get_available_sections_for_subject(subject_id: int) -> list[str]:
             SELECT DISTINCT section
             FROM materials
             WHERE subject_id=?
-              AND section IN ('theory','discussion','lab','field_trip')
+              AND section IN (
+                'theory','discussion','lab','field_trip',
+                'vocabulary','references','skills','open_source_projects'
+              )
               AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
             """,
             (subject_id,),

--- a/database/init.sql
+++ b/database/init.sql
@@ -129,7 +129,10 @@ ON ingestions(admin_id);
 CREATE TABLE IF NOT EXISTS materials (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     subject_id INTEGER NOT NULL,
-    section TEXT NOT NULL CHECK(section IN ('theory','discussion','lab','field_trip','syllabus','apps')),
+    section TEXT NOT NULL CHECK(section IN (
+        'theory','discussion','lab','field_trip','syllabus','apps',
+        'vocabulary','references','skills','open_source_projects'
+    )),
     category TEXT NOT NULL CHECK(category IN (
     'lecture','slides','audio','exam','booklet','board_images','video','simulation',
     'summary','notes','external_link','mind_map','transcript','related'

--- a/database/migrate_materials_sections.sql
+++ b/database/migrate_materials_sections.sql
@@ -1,0 +1,49 @@
+BEGIN TRANSACTION;
+ALTER TABLE materials RENAME TO materials_old;
+CREATE TABLE materials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id INTEGER NOT NULL,
+    section TEXT NOT NULL CHECK(section IN (
+        'theory','discussion','lab','field_trip','syllabus','apps',
+        'vocabulary','references','skills','open_source_projects'
+    )),
+    category TEXT NOT NULL CHECK(category IN (
+        'lecture','slides','audio','exam','booklet','board_images','video','simulation',
+        'summary','notes','external_link','mind_map','transcript','related'
+    )),
+    title TEXT NOT NULL,
+    url TEXT,
+    year_id INTEGER,
+    lecturer_id INTEGER,
+    tg_storage_chat_id INTEGER,
+    tg_storage_msg_id INTEGER,
+    file_unique_id TEXT,
+    source_chat_id INTEGER,
+    source_topic_id INTEGER,
+    source_message_id INTEGER,
+    created_by_admin_id INTEGER,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (subject_id) REFERENCES subjects(id),
+    FOREIGN KEY (year_id) REFERENCES years(id),
+    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id),
+    FOREIGN KEY (created_by_admin_id) REFERENCES admins(id)
+);
+INSERT INTO materials (
+    id, subject_id, section, category, title, url, year_id, lecturer_id,
+    tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
+    source_chat_id, source_topic_id, source_message_id,
+    created_by_admin_id, created_at
+)
+SELECT
+    id, subject_id, section, category, title, url, year_id, lecturer_id,
+    tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
+    source_chat_id, source_topic_id, source_message_id,
+    created_by_admin_id, created_at
+FROM materials_old;
+DROP TABLE materials_old;
+CREATE INDEX IF NOT EXISTS idx_materials_subject ON materials(subject_id);
+CREATE INDEX IF NOT EXISTS idx_materials_year ON materials(year_id);
+CREATE INDEX IF NOT EXISTS idx_materials_lecturer ON materials(lecturer_id);
+CREATE INDEX IF NOT EXISTS idx_materials_admin ON materials(created_by_admin_id);
+CREATE INDEX IF NOT EXISTS idx_materials_section_created_at ON materials(section, created_at);
+COMMIT;

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+import aiosqlite
+
+os.environ.setdefault("BOT_TOKEN", "1")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+from bot.db import base as db_base
+from bot.db import subjects, materials
+
+
+def test_new_sections_returned(tmp_path):
+    async def _inner():
+        db_path = tmp_path / "test.db"
+        db_base.DB_PATH = subjects.DB_PATH = materials.DB_PATH = str(db_path)
+        await db_base.init_db()
+        async with aiosqlite.connect(db_base.DB_PATH) as db:
+            await db.execute("INSERT INTO levels (name) VALUES ('L1')")
+            await db.execute("INSERT INTO terms (name) VALUES ('T1')")
+            await db.execute(
+                "INSERT INTO subjects (code, name, level_id, term_id) VALUES ('S1','Sub1',1,1)"
+            )
+            await db.commit()
+        new_sections = ["vocabulary", "references", "skills", "open_source_projects"]
+        for sec in new_sections:
+            await materials.insert_material(1, sec, "lecture", f"{sec} title", url="http://ex.com")
+        sections = await subjects.get_available_sections_for_subject(1)
+        assert set(new_sections).issubset(set(sections))
+    asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- allow materials table to store new sections like vocabulary, references, skills, and open source projects
- include new sections in subject navigation queries
- add migration and tests for new material sections

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b635b710108329b020fa80fae9c38c