### PR TITLE
Add syllabus section to subject queries

### DIFF
--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -259,7 +259,7 @@ async def get_available_sections_for_subject(subject_id: int) -> list[str]:
             FROM materials
             WHERE subject_id=?
               AND section IN (
-                'theory','discussion','lab','field_trip',
+                'theory','discussion','lab','field_trip','syllabus',
                 'vocabulary','references','skills','open_source_projects'
               )
               AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -25,6 +25,9 @@ def test_new_sections_returned(tmp_path):
         new_sections = ["vocabulary", "references", "skills", "open_source_projects"]
         for sec in new_sections:
             await materials.insert_material(1, sec, "lecture", f"{sec} title", url="http://ex.com")
+        # Insert a syllabus record and ensure it is returned
+        await materials.insert_material(1, "syllabus", "syllabus", "syllabus title", url="http://ex.com")
         sections = await subjects.get_available_sections_for_subject(1)
         assert set(new_sections).issubset(set(sections))
+        assert "syllabus" in sections
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- Include `syllabus` in the list of sections returned for a subject
- Ensure tests cover syllabus section availability

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7063724388329bc2df539ddb0316e