### PR TITLE
Add lecture materials navigation

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -3,6 +3,18 @@ import re
 
 from .base import DB_PATH
 
+# Arabic labels for lecture material types used in navigation menus
+LECTURE_TYPE_LABELS = {
+    "lecture": "ملف المحاضرة \U0001F4C4",
+    "slides": "السلايدات \U0001F4D1",
+    "audio": "الصوت \U0001F50A",
+    "board_images": "صور اللوح \U0001F5BC\uFE0F",
+    "video": "الفيديو \U0001F3A5",
+    "mind_map": "الخريطة الذهنية \U0001F5FA\uFE0F",
+    "transcript": "التفريغ \u270D\uFE0F",
+    "related": "مواد مرتبطة \U0001F517",
+}
+
 
 def _strip_lecture_prefix(title: str) -> str:
     """Return title without the "محاضرة N:" prefix if present."""

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -11,9 +11,10 @@ from ..db import (
     get_available_sections_for_subject,
     get_years_for_subject_section,
     get_lecturers_for_subject_section,
-    list_lecture_titles,
+    get_lectures_by_lecturer_year,
     list_lecture_titles_by_year,
     list_categories_for_subject_section_year,
+    get_types_for_lecture,
     can_view,
     list_term_resource_kinds,
 )
@@ -137,6 +138,7 @@ CHILD_KIND: Dict[str, str] = {
     "year": "year_option",
     "year_option": "lecturer",
     "lecturer": "lecture",
+    "lecture": "lecture_type",
 }
 
 
@@ -213,7 +215,8 @@ KIND_TO_LOADER: Dict[str, Loader] = {
     "section_option": get_section_option_children,
     "year": get_year_menu_items,
     "year_option": get_year_option_children,
-    "lecturer": list_lecture_titles,
+    "lecturer": get_lectures_by_lecturer_year,
+    "lecture": get_types_for_lecture,
 }
 
 


### PR DESCRIPTION
## Summary
- map lecture nodes to new lecture_type children and load available types
- expose lecture material labels and loader in navigation tree
- handle lecture material buttons and copy stored messages to chat

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70fcc13988329b788c037c3fd4522