### PR TITLE
Enable direct syllabus access in navigation

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -420,6 +420,27 @@ async def get_materials_by_category(
         return await cur.fetchall()
 
 
+async def get_latest_syllabus_material(subject_id: int):
+    """Return latest syllabus material for a subject or None.
+
+    The returned tuple is ``(tg_storage_chat_id, tg_storage_msg_id, url)``.
+    """
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            SELECT tg_storage_chat_id, tg_storage_msg_id, url
+            FROM materials
+            WHERE subject_id=? AND category='syllabus'
+              AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (subject_id,),
+        )
+        return await cur.fetchone()
+
+
 async def list_categories_for_subject_section_year(
     subject_id: int,
     section: str,

--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -267,4 +267,18 @@ async def get_available_sections_for_subject(subject_id: int) -> list[str]:
             (subject_id,),
         )
         rows = await cur.fetchall()
-        return [r[0] for r in rows]
+        sections = [r[0] for r in rows]
+
+        cur = await db.execute(
+            """
+            SELECT 1 FROM materials
+            WHERE subject_id=? AND category='syllabus'
+              AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
+            LIMIT 1
+            """,
+            (subject_id,),
+        )
+        if await cur.fetchone() and "syllabus" not in sections:
+            sections.append("syllabus")
+
+        return sections

--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -14,7 +14,12 @@ from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
 from ..navigation.nav_stack import NavStack
-from ..navigation.tree import get_children, CHILD_KIND, CACHE_TTL_SECONDS
+from ..navigation.tree import (
+    get_children,
+    CHILD_KIND,
+    CACHE_TTL_SECONDS,
+    get_latest_syllabus_material,
+)
 from ..keyboards.builders.paginated import build_children_keyboard
 from ..keyboards.builders.main_menu import build_main_menu
 from ..db import (
@@ -308,6 +313,48 @@ async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             if str(item_id) == ident_str:
                 label = item_label
                 break
+        if kind == "section":
+            subj_id, sect = ident if isinstance(ident, tuple) else (ident, None)
+            if sect == "syllabus":
+                try:
+                    res = await get_latest_syllabus_material(subj_id)
+                    if res:
+                        chat_id, msg_id, url = res
+                        if chat_id and msg_id:
+                            target_chat = (
+                                query.message.chat_id
+                                if query
+                                else update.effective_chat.id
+                            )
+                            thread_id = (
+                                query.message.message_thread_id
+                                if query and query.message
+                                else None
+                            )
+                            await context.bot.copy_message(
+                                chat_id=target_chat,
+                                from_chat_id=chat_id,
+                                message_id=msg_id,
+                                message_thread_id=thread_id,
+                            )
+                        elif url:
+                            await (query.message if query else update.message).reply_text(url)
+                        else:
+                            await (query.message if query else update.message).reply_text(
+                                "المادة غير متاحة بعد.",
+                            )
+                    else:
+                        await (query.message if query else update.message).reply_text(
+                            "المادة غير متاحة بعد.",
+                        )
+                except Exception:
+                    await (query.message if query else update.message).reply_text(
+                        "عذرًا، تعذر جلب المادة.",
+                    )
+                    logger.exception("Error sending syllabus material")
+                if query:
+                    await query.answer()
+                return
         if kind == "lecture_type":
             parent = stack.peek()
             subj_id = sect = year_id = None

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -17,6 +17,7 @@ from ..db import (
     get_types_for_lecture,
     can_view,
     list_term_resource_kinds,
+    get_latest_syllabus_material,
 )
 
 # ---------------------------------------------------------------------------
@@ -234,4 +235,10 @@ async def get_children(kind: str, id: Any | None = None, user_id: int | None = N
     node = Node(kind, args)
     return await node.children(user_id)
 
-__all__ = ["Node", "invalidate", "KIND_TO_LOADER", "get_children"]
+__all__ = [
+    "Node",
+    "invalidate",
+    "KIND_TO_LOADER",
+    "get_children",
+    "get_latest_syllabus_material",
+]

--- a/tests/test_navigation_syllabus.py
+++ b/tests/test_navigation_syllabus.py
@@ -1,0 +1,93 @@
+import asyncio
+import os
+import aiosqlite
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+os.environ.setdefault("BOT_TOKEN", "1")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+from bot.db import base as db_base
+from bot.db import subjects, materials
+from bot.navigation import NavStack
+
+
+class DummyMessage:
+    def __init__(self):
+        self.sent = []
+        self.chat_id = 100
+        self.message_thread_id = 200
+
+    async def reply_text(self, text, reply_markup=None):
+        self.sent.append((text, reply_markup))
+
+    async def edit_message_text(self, text, reply_markup=None):
+        self.sent.append((text, reply_markup))
+
+
+def test_syllabus_section_sends_material(tmp_path):
+    async def _inner():
+        db_path = tmp_path / "test.db"
+        db_base.DB_PATH = subjects.DB_PATH = materials.DB_PATH = str(db_path)
+        await db_base.init_db()
+        async with aiosqlite.connect(db_base.DB_PATH) as db:
+            await db.execute("INSERT INTO levels (name) VALUES ('L1')")
+            await db.execute("INSERT INTO terms (name) VALUES ('T1')")
+            await db.execute(
+                "INSERT INTO subjects (code, name, level_id, term_id) VALUES ('S1','Sub1',1,1)"
+            )
+            await db.commit()
+
+        await materials.insert_material(
+            1, "theory", "lecture", "t", tg_storage_chat_id=1, tg_storage_msg_id=11
+        )
+        await materials.insert_material(
+            1, "lab", "lecture", "l", tg_storage_chat_id=1, tg_storage_msg_id=12
+        )
+        await materials.insert_material(
+            1, "theory", "syllabus", "sy", tg_storage_chat_id=9, tg_storage_msg_id=99
+        )
+
+        navtree = import_module("bot.handlers.navigation_tree")
+
+        ctx = SimpleNamespace(user_data={})
+        children = await navtree._load_children(ctx, "subject", 1, user_id=None)
+        assert ("section", "1-syllabus", "التوصيف 📄") in children
+
+        stack = NavStack(ctx.user_data)
+        stack.push(("subject", 1, "Sub1"))
+
+        copy_calls = []
+
+        async def fake_copy_message(chat_id, from_chat_id, message_id, message_thread_id=None):
+            copy_calls.append((chat_id, from_chat_id, message_id, message_thread_id))
+
+        message = DummyMessage()
+        query = SimpleNamespace(
+            data="section:1-syllabus",
+            message=message,
+            answer=AsyncMock(),
+            from_user=SimpleNamespace(id=1),
+        )
+        update = SimpleNamespace(
+            callback_query=query,
+            effective_user=SimpleNamespace(id=1),
+        )
+        context = SimpleNamespace(
+            user_data=ctx.user_data,
+            bot=SimpleNamespace(copy_message=fake_copy_message),
+        )
+
+        await navtree.navtree_callback(update, context)
+
+        assert copy_calls == [(
+            message.chat_id,
+            9,
+            99,
+            message.message_thread_id,
+        )]
+
+    asyncio.run(_inner())
+

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -25,8 +25,8 @@ def test_new_sections_returned(tmp_path):
         new_sections = ["vocabulary", "references", "skills", "open_source_projects"]
         for sec in new_sections:
             await materials.insert_material(1, sec, "lecture", f"{sec} title", url="http://ex.com")
-        # Insert a syllabus record and ensure it is returned
-        await materials.insert_material(1, "syllabus", "syllabus", "syllabus title", url="http://ex.com")
+        # Insert a syllabus record with category='syllabus' regardless of section
+        await materials.insert_material(1, "theory", "syllabus", "syllabus title", url="http://ex.com")
         sections = await subjects.get_available_sections_for_subject(1)
         assert set(new_sections).issubset(set(sections))
         assert "syllabus" in sections


### PR DESCRIPTION
## Summary
- include syllabus section when materials contain category `syllabus`
- send latest syllabus material immediately when syllabus section is selected
- cover syllabus retrieval with new tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7191cad2c83299898874916b4ea88