### PR TITLE
Expand term resource kinds and navigation

### DIFF
--- a/bot/db/term_resources.py
+++ b/bot/db/term_resources.py
@@ -18,6 +18,10 @@ class TermResourceKind(str, Enum):
     SKILLS = "skills"
     FORUMS = "forums"
     SITES = "sites"
+    GLOSSARY = "glossary"
+    PRACTICAL = "practical"
+    REFERENCES = "references"
+    OPEN_SOURCE_PROJECTS = "open_source_projects"
 
 
 def _validate_kind(kind: str | TermResourceKind) -> str:

--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -50,11 +50,12 @@ SECTION_LABELS = {
 
 CATEGORY_OPTIONS = {
     "syllabus",
-    "vocabulary",
+    "glossary",
     "applications",
     "references",
     "skills",
     "open_source_projects",
+    "practical",
 }
 
 

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -46,6 +46,10 @@ TERM_RESOURCE_LABELS = {
     "skills": "مهارات مطلوبة 🧠",
     "forums": "منتديات للنقاش 💬",
     "sites": "مواقع إلكترونية 🌐",
+    "glossary": "المفردات الدراسية 📖",
+    "practical": "الواقع التطبيقي ⚙️",
+    "references": "مراجع 📚",
+    "open_source_projects": "مشاريع مفتوحة المصدر 🛠️",
 }
 
 YEAR_OPTION_LABELS = {
@@ -56,11 +60,12 @@ YEAR_OPTION_LABELS = {
 
 SECTION_CATEGORY_LABELS = {
     "syllabus": "التوصيف \U0001F4C4",
-    "vocabulary": "المفردات \U0001F4D6",
+    "glossary": "المفردات الدراسية \U0001F4D6",
     "applications": "تطبيقات مفيدة \U0001F4F1",
     "references": "مراجع \U0001F4DA",
     "skills": "مهارات مطلوبة \U0001F9E0",
     "open_source_projects": "مشاريع مفتوحة المصدر \U0001F6E0\uFE0F",
+    "practical": "الواقع التطبيقي \u2699\uFE0F",
 }
 
 async def get_term_menu_items(level_id: int, term_id: int):

--- a/database/init.sql
+++ b/database/init.sql
@@ -178,7 +178,8 @@ CREATE TABLE IF NOT EXISTS term_resources (
     term_id INTEGER NOT NULL,
     kind TEXT NOT NULL CHECK(kind IN (
         'attendance','study_plan','channels','outcomes','tips',
-        'projects','programs','apps','skills','forums','sites'
+        'projects','programs','apps','skills','forums','sites',
+        'glossary','practical','references','open_source_projects'
     )),
     tg_storage_chat_id INTEGER NOT NULL,
     tg_storage_msg_id INTEGER NOT NULL,

--- a/database/migrate_term_resources_level.sql
+++ b/database/migrate_term_resources_level.sql
@@ -6,7 +6,8 @@ CREATE TABLE term_resources (
     term_id INTEGER NOT NULL,
     kind TEXT NOT NULL CHECK(kind IN (
         'attendance','study_plan','channels','outcomes','tips',
-        'projects','programs','apps','skills','forums','sites'
+        'projects','programs','apps','skills','forums','sites',
+        'glossary','practical','references','open_source_projects'
     )),
     tg_storage_chat_id INTEGER NOT NULL,
     tg_storage_msg_id INTEGER NOT NULL,

--- a/tests/test_navigation_categories.py
+++ b/tests/test_navigation_categories.py
@@ -16,11 +16,12 @@ from bot.navigation import NavStack
 
 CATEGORIES = [
     ("syllabus", "التوصيف 📄", 9, 99),
-    ("vocabulary", "المفردات 📖", 10, 100),
+    ("glossary", "المفردات الدراسية 📖", 10, 100),
     ("applications", "تطبيقات مفيدة 📱", 11, 101),
     ("references", "مراجع 📚", 12, 102),
     ("skills", "مهارات مطلوبة 🧠", 13, 103),
     ("open_source_projects", "مشاريع مفتوحة المصدر 🛠️", 14, 104),
+    ("practical", "الواقع التطبيقي ⚙️", 15, 105),
 ]
 
 
@@ -50,11 +51,11 @@ def test_section_category_buttons_send_material(tmp_path):
             subject_id INTEGER NOT NULL,
             section TEXT NOT NULL CHECK(section IN (
                 'theory','discussion','lab','field_trip','syllabus','apps',
-                'vocabulary','references','skills','open_source_projects'
+                'vocabulary','references','skills','open_source_projects','glossary','practical'
             )),
             category TEXT NOT NULL CHECK(category IN (
                 'lecture','slides','audio','exam','exam_mid','exam_final','booklet','board_images','video','simulation',
-                'summary','notes','external_link','mind_map','transcript','related','syllabus','vocabulary','applications','references','skills','open_source_projects'
+                'summary','notes','external_link','mind_map','transcript','related','syllabus','vocabulary','applications','references','skills','open_source_projects','glossary','practical'
             )),
             title TEXT NOT NULL,
             url TEXT,


### PR DESCRIPTION
## Summary
- add glossary, practical, references and open_source_projects term resource kinds
- expand schema, migrations and navigation labels for new kinds
- adjust tests for new categories

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7215a3bb48329b527f6a14a406e9d