### PR TITLE
Add misc term resource label

### DIFF
--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -50,6 +50,7 @@ TERM_RESOURCE_LABELS = {
     "practical": "الواقع التطبيقي ⚙️",
     "references": "مراجع 📚",
     "open_source_projects": "مشاريع مفتوحة المصدر 🛠️",
+    "misc": "محتوى متنوع 📦",
 }
 
 YEAR_OPTION_LABELS = {

--- a/tests/test_term_options.py
+++ b/tests/test_term_options.py
@@ -43,7 +43,7 @@ def test_term_with_resources(monkeypatch, navtree):
 
         async def fake_list_term_resource_kinds(level_id: int, term_id: int):
             assert (level_id, term_id) == (1, 2)
-            return ["attendance"]
+            return ["attendance", "misc"]
 
         async def fake_can_view(user_id, kind, item_id):
             return True
@@ -56,5 +56,6 @@ def test_term_with_resources(monkeypatch, navtree):
         children = await navtree._load_children(ctx, "term", (1, 2), user_id=1)
         assert ("term_option", "subjects", "عرض المواد") in children
         assert ("term_option", "attendance", "جدول الحضور 🗓️") in children
+        assert ("term_option", "misc", "محتوى متنوع 📦") in children
 
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- add navigation label for miscellaneous term resources
- verify term menu shows misc resources with proper label

## Testing
- `PYTHONPATH=. pytest tests/test_term_resource_ingestion.py::test_misc_term_resource_ingestion tests/test_term_options.py::test_term_with_resources -q`

------
https://chatgpt.com/codex/tasks/task_e_68b730244cb083299daa5ed0626ca46c