### PR TITLE
Add navigation categories to materials table

### DIFF
--- a/bot/db/subjects.py
+++ b/bot/db/subjects.py
@@ -259,8 +259,7 @@ async def get_available_sections_for_subject(subject_id: int) -> list[str]:
             FROM materials
             WHERE subject_id=?
               AND section IN (
-                'theory','discussion','lab','field_trip','syllabus',
-                'vocabulary','references','skills','open_source_projects'
+                'theory','discussion','lab','field_trip','syllabus','apps'
               )
               AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
             """,

--- a/database/init.sql
+++ b/database/init.sql
@@ -130,12 +130,12 @@ CREATE TABLE IF NOT EXISTS materials (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     subject_id INTEGER NOT NULL,
     section TEXT NOT NULL CHECK(section IN (
-        'theory','discussion','lab','field_trip','syllabus','apps',
-        'vocabulary','references','skills','open_source_projects'
+        'theory','discussion','lab','field_trip','syllabus','apps'
     )),
     category TEXT NOT NULL CHECK(category IN (
     'lecture','slides','audio','exam','exam_mid','exam_final','booklet','board_images','video','simulation',
-    'summary','notes','external_link','mind_map','transcript','related','syllabus'
+    'summary','notes','external_link','mind_map','transcript','related','syllabus',
+    'vocabulary','applications','references','skills','open_source_projects','glossary','practical'
     )),
 
     title TEXT NOT NULL,

--- a/database/migrate_materials_category_navigation.sql
+++ b/database/migrate_materials_category_navigation.sql
@@ -1,0 +1,67 @@
+BEGIN TRANSACTION;
+ALTER TABLE materials RENAME TO materials_old;
+CREATE TABLE materials (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    subject_id INTEGER NOT NULL,
+    section TEXT NOT NULL CHECK(section IN (
+        'theory','discussion','lab','field_trip','syllabus','apps'
+    )),
+    category TEXT NOT NULL CHECK(category IN (
+        'lecture','slides','audio','exam','exam_mid','exam_final','booklet','board_images','video','simulation',
+        'summary','notes','external_link','mind_map','transcript','related','syllabus',
+        'vocabulary','applications','references','skills','open_source_projects','glossary','practical'
+    )),
+    title TEXT NOT NULL,
+    url TEXT,
+    year_id INTEGER,
+    lecturer_id INTEGER,
+    tg_storage_chat_id INTEGER,
+    tg_storage_msg_id INTEGER,
+    file_unique_id TEXT,
+    source_chat_id INTEGER,
+    source_topic_id INTEGER,
+    source_message_id INTEGER,
+    created_by_admin_id INTEGER,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (subject_id) REFERENCES subjects(id),
+    FOREIGN KEY (year_id) REFERENCES years(id),
+    FOREIGN KEY (lecturer_id) REFERENCES lecturers(id),
+    FOREIGN KEY (created_by_admin_id) REFERENCES admins(id)
+);
+INSERT INTO materials (
+    id, subject_id, section, category, title, url, year_id, lecturer_id,
+    tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
+    source_chat_id, source_topic_id, source_message_id,
+    created_by_admin_id, created_at
+)
+SELECT
+    id,
+    subject_id,
+    CASE
+        WHEN section IN ('vocabulary','applications','references','skills','open_source_projects','glossary','practical') THEN 'theory'
+        ELSE section
+    END AS section,
+    CASE
+        WHEN section IN ('vocabulary','applications','references','skills','open_source_projects','glossary','practical') THEN section
+        ELSE category
+    END AS category,
+    title,
+    url,
+    year_id,
+    lecturer_id,
+    tg_storage_chat_id,
+    tg_storage_msg_id,
+    file_unique_id,
+    source_chat_id,
+    source_topic_id,
+    source_message_id,
+    created_by_admin_id,
+    created_at
+FROM materials_old;
+DROP TABLE materials_old;
+CREATE INDEX IF NOT EXISTS idx_materials_subject ON materials(subject_id);
+CREATE INDEX IF NOT EXISTS idx_materials_year ON materials(year_id);
+CREATE INDEX IF NOT EXISTS idx_materials_lecturer ON materials(lecturer_id);
+CREATE INDEX IF NOT EXISTS idx_materials_admin ON materials(created_by_admin_id);
+CREATE INDEX IF NOT EXISTS idx_materials_section_created_at ON materials(section, created_at);
+COMMIT;

--- a/tests/test_navigation_categories.py
+++ b/tests/test_navigation_categories.py
@@ -44,53 +44,7 @@ def test_section_category_buttons_send_material(tmp_path):
         db_base.DB_PATH = subjects.DB_PATH = materials.DB_PATH = str(db_path)
         await db_base.init_db()
 
-        upgrade_sql = """
-        ALTER TABLE materials RENAME TO materials_old;
-        CREATE TABLE materials (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            subject_id INTEGER NOT NULL,
-            section TEXT NOT NULL CHECK(section IN (
-                'theory','discussion','lab','field_trip','syllabus','apps',
-                'vocabulary','references','skills','open_source_projects','glossary','practical'
-            )),
-            category TEXT NOT NULL CHECK(category IN (
-                'lecture','slides','audio','exam','exam_mid','exam_final','booklet','board_images','video','simulation',
-                'summary','notes','external_link','mind_map','transcript','related','syllabus','vocabulary','applications','references','skills','open_source_projects','glossary','practical'
-            )),
-            title TEXT NOT NULL,
-            url TEXT,
-            year_id INTEGER,
-            lecturer_id INTEGER,
-            tg_storage_chat_id INTEGER,
-            tg_storage_msg_id INTEGER,
-            file_unique_id TEXT,
-            source_chat_id INTEGER,
-            source_topic_id INTEGER,
-            source_message_id INTEGER,
-            created_by_admin_id INTEGER,
-            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (subject_id) REFERENCES subjects(id),
-            FOREIGN KEY (year_id) REFERENCES years(id),
-            FOREIGN KEY (lecturer_id) REFERENCES lecturers(id),
-            FOREIGN KEY (created_by_admin_id) REFERENCES admins(id)
-        );
-        INSERT INTO materials (
-            id, subject_id, section, category, title, url, year_id, lecturer_id,
-            tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
-            source_chat_id, source_topic_id, source_message_id,
-            created_by_admin_id, created_at
-        )
-        SELECT
-            id, subject_id, section, category, title, url, year_id, lecturer_id,
-            tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
-            source_chat_id, source_topic_id, source_message_id,
-            created_by_admin_id, created_at
-        FROM materials_old;
-        DROP TABLE materials_old;
-        """
-
         async with aiosqlite.connect(db_base.DB_PATH) as db:
-            await db.executescript(upgrade_sql)
             await db.execute("INSERT INTO levels (name) VALUES ('L1')")
             await db.execute("INSERT INTO terms (name) VALUES ('T1')")
             await db.execute(

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -22,12 +22,28 @@ def test_new_sections_returned(tmp_path):
                 "INSERT INTO subjects (code, name, level_id, term_id) VALUES ('S1','Sub1',1,1)"
             )
             await db.commit()
-        new_sections = ["vocabulary", "references", "skills", "open_source_projects"]
-        for sec in new_sections:
-            await materials.insert_material(1, sec, "lecture", f"{sec} title", url="http://ex.com")
-        # Insert a syllabus record with category='syllabus' regardless of section
-        await materials.insert_material(1, "theory", "syllabus", "syllabus title", url="http://ex.com")
+
+        new_categories = [
+            "vocabulary",
+            "applications",
+            "references",
+            "skills",
+            "open_source_projects",
+            "glossary",
+            "practical",
+        ]
+        for cat in new_categories:
+            await materials.insert_material(
+                1, "theory", cat, f"{cat} title", url="http://ex.com"
+            )
+        # Insert a syllabus record with category='syllabus'
+        await materials.insert_material(
+            1, "theory", "syllabus", "syllabus title", url="http://ex.com"
+        )
         sections = await subjects.get_available_sections_for_subject(1)
-        assert set(new_sections).issubset(set(sections))
+        assert "theory" in sections
         assert "syllabus" in sections
+        for cat in new_categories:
+            assert cat not in sections
+
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- expand `materials.category` options to include navigation categories like vocabulary and glossary
- migrate existing `materials` rows, moving old section-based records into the new categories
- adjust section listing and tests for updated schema

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7361eff248329947c86564fa52a29