### PR TITLE
feat: add glossary alias

### DIFF
--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -112,6 +112,7 @@ TERM_RESOURCE_ALIASES = {
     ),
     "glossary": (
         "المفردات_الدراسية",
+        "المفردات_الدرسية",
         "المفردات",
         "study_vocab",
         "glossary",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from bot.parser.hashtags import TERM_RESOURCE_ALIASES
 
 
-# Map each term resource ``kind`` to the four accepted hashtag variants
+# Map each term resource ``kind`` to the accepted hashtag variants
 # prefixed with ``#`` as they would appear in messages.
 TERM_RESOURCE_TAGS = {
     kind: tuple(f"#{alias}" for alias in aliases)

--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -46,3 +46,9 @@ def test_parse_hashtags_section(tag, expected):
     info, error = parse_hashtags(tag)
     assert error is None
     assert info.section == expected
+
+
+def test_parse_hashtags_glossary_new_alias():
+    info, error = parse_hashtags("#المفردات_الدرسية")
+    assert error is None
+    assert info.content_type == "glossary"


### PR DESCRIPTION
## Summary
- add `المفردات_الدرسية` as an alias for glossary hashtags
- expand tests for glossary hashtag parsing

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7392aabb08329b900faae04d1a992