### PR TITLE
Migrate syllabus term resources to materials and enforce topic binding

### DIFF
--- a/bot/db/base.py
+++ b/bot/db/base.py
@@ -291,13 +291,14 @@ async def _migrate(db: aiosqlite.Connection) -> None:
                     WHEN 'references' THEN 'مراجع'
                     WHEN 'skills' THEN 'مهارات مطلوبة'
                     WHEN 'open_source_projects' THEN 'مشاريع مفتوحة المصدر'
+                    WHEN 'syllabus' THEN 'التوصيف'
                 END,
                 tr.tg_storage_chat_id,
                 tr.tg_storage_msg_id
             FROM term_resources_old tr
             JOIN subjects s ON s.level_id = tr.level_id AND s.term_id = tr.term_id
             WHERE tr.kind IN (
-                'glossary','practical','references','skills','open_source_projects'
+                'glossary','practical','references','skills','open_source_projects','syllabus'
             );
             DROP TABLE term_resources_old;
             """

--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -156,22 +156,14 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             return
     binding = None
     if category not in TERM_RESOURCE_TYPES:
-        if thread_id is None:
+        if thread_id is not None:
+            binding = await get_binding(chat.id, thread_id)
+            logger.debug("binding=%s", binding)
+        if thread_id is None or binding is None:
             await send_ephemeral(
                 context,
                 message.chat_id,
-                "هذا النوع يتطلب ربط الـTopic بمادة/قسم عبر /insert_sub.",
-                reply_to_message_id=message.message_id,
-                message_thread_id=message.message_thread_id,
-            )
-            return
-        binding = await get_binding(chat.id, thread_id)
-        logger.debug("binding=%s", binding)
-        if binding is None:
-            await send_ephemeral(
-                context,
-                message.chat_id,
-                "هذا النوع يتطلب ربط الـTopic بمادة/قسم عبر /insert_sub.",
+                "لا يمكن رفع هذا النوع خارج Topic مرتبط بمادة/قسم. استخدم /insert_sub للربط.",
                 reply_to_message_id=message.message_id,
                 message_thread_id=message.message_thread_id,
             )

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -73,6 +73,7 @@ async def get_term_menu_items(level_id: int, term_id: int):
         "references",
         "skills",
         "open_source_projects",
+        "syllabus",
     }
     kinds = [
         k for k in kinds if k not in excluded and k not in SECTION_CATEGORY_LABELS

--- a/tests/test_navigation_term_exclusions.py
+++ b/tests/test_navigation_term_exclusions.py
@@ -1,0 +1,43 @@
+import asyncio
+from importlib import import_module
+import os
+
+os.environ.setdefault("BOT_TOKEN", "1")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+
+def test_material_tags_hidden_in_term(monkeypatch):
+    async def _inner():
+        tree_module = import_module("bot.navigation.tree")
+        excluded = [
+            "glossary",
+            "practical",
+            "references",
+            "skills",
+            "open_source_projects",
+            "syllabus",
+        ]
+
+        async def fake_list_term_resource_kinds(level_id, term_id):
+            return excluded + ["attendance"]
+
+        async def fake_has_materials_by_category(subject_id, section, cat):
+            return cat in excluded
+
+        monkeypatch.setattr(tree_module, "list_term_resource_kinds", fake_list_term_resource_kinds)
+        monkeypatch.setattr(tree_module, "has_materials_by_category", fake_has_materials_by_category)
+        tree_module.invalidate()
+
+        term_items = await tree_module.get_term_menu_items(1, 2)
+        term_ids = [k for k, _ in term_items]
+        assert "subjects" in term_ids and "attendance" in term_ids
+        for k in excluded:
+            assert k not in term_ids
+
+        section_items = await tree_module.get_section_menu_items(1, "theory")
+        section_ids = [k for k, _ in section_items]
+        for k in excluded:
+            assert k in section_ids
+
+    asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- migrate legacy `syllabus` term resources into `materials` with theory section
- ensure ingestion requires topic binding for material uploads and update term menu exclusions
- add tests guarding navigation tree visibility for moved categories

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73fb2a220832981e206f00733827d