### PR TITLE
test: cover additional content hashtags

### DIFF
--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -52,3 +52,28 @@ def test_parse_hashtags_glossary_new_alias():
     info, error = parse_hashtags("#المفردات_الدرسية")
     assert error is None
     assert info.content_type == "glossary"
+
+
+@pytest.mark.parametrize(
+    "tag, expected",
+    [
+        ("#التوصيف", "syllabus"),
+        ("#المفردات_الدراسية", "glossary"),
+        ("#الواقع_التطبيقي", "practical"),
+        ("#مراجع", "references"),
+        ("#مهارات", "skills"),
+        ("#مشاريع_مفتوحة_المصدر", "open_source_projects"),
+    ],
+    ids=[
+        "التوصيف",
+        "المفردات_الدراسية",
+        "الواقع_التطبيقي",
+        "مراجع",
+        "مهارات",
+        "مشاريع_مفتوحة_المصدر",
+    ],
+)
+def test_parse_hashtags_content_type(tag, expected):
+    info, error = parse_hashtags(tag)
+    assert error is None
+    assert info.content_type == expected


### PR DESCRIPTION
## Summary
- add parametrized tests for new content hashtags

## Testing
- `PYTHONPATH=. pytest tests/test_hashtags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b770d787ec8329822ea00a58b8169a