### PR TITLE
Expand category section tests

### DIFF
--- a/tests/test_navigation_categories.py
+++ b/tests/test_navigation_categories.py
@@ -70,6 +70,12 @@ def test_section_category_buttons_send_material(tmp_path):
 
         ctx = SimpleNamespace(user_data={})
         children = await navtree._load_children(ctx, "section", (1, "theory"), user_id=None)
+
+        category_ids = {cat for cat, _label, _chat_id, _msg_id in CATEGORIES}
+        category_children = [
+            c for c in children if c[1].split("-")[-1] in category_ids
+        ]
+        assert len(category_children) == len(CATEGORIES)
         for cat, label, _, _ in CATEGORIES:
             assert ("section_option", f"1-theory-{cat}", label) in children
 
@@ -107,6 +113,8 @@ def test_section_category_buttons_send_material(tmp_path):
                 msg_id,
                 message.message_thread_id,
             )
+
+        assert len(copy_calls) == len(CATEGORIES)
 
     asyncio.run(_inner())
 

--- a/tests/test_navigation_section_skip.py
+++ b/tests/test_navigation_section_skip.py
@@ -108,8 +108,14 @@ def test_single_section_skips_and_shows_categories(tmp_path):
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
+    category_buttons = [
+        b
+        for b in buttons
+        if any(b == f"nav:section_option:1-theory-{cat}" for cat, _label in CATEGORIES)
+    ]
+    assert len(category_buttons) == len(CATEGORIES)
     for cat, _label in CATEGORIES:
-        assert f"nav:section_option:1-theory-{cat}" in buttons
+        assert f"nav:section_option:1-theory-{cat}" in category_buttons
 
 
 def test_multiple_sections_no_skip_and_no_categories(tmp_path):

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -23,16 +23,15 @@ def test_new_sections_returned(tmp_path):
             )
             await db.commit()
 
-        new_categories = [
-            "vocabulary",
-            "applications",
+        section_categories = [
             "references",
             "skills",
             "open_source_projects",
             "glossary",
             "practical",
         ]
-        for cat in new_categories:
+        extra_categories = ["vocabulary"]
+        for cat in section_categories + extra_categories:
             await materials.insert_material(
                 1, "theory", cat, f"{cat} title", url="http://ex.com"
             )
@@ -44,16 +43,10 @@ def test_new_sections_returned(tmp_path):
         assert "theory" in sections
         assert "syllabus" in sections
 
-        for cat in [
-            "references",
-            "skills",
-            "open_source_projects",
-            "glossary",
-            "practical",
-        ]:
+        for cat in section_categories:
             assert cat in sections
 
-        for cat in ["vocabulary", "applications"]:
+        for cat in extra_categories:
             assert cat not in sections
 
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- update subject section tests for new category sections
- verify navigation tests cover six category buttons and their actions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78f7339388329939004f296b5ff01