### PR TITLE
feat: separate section and card labels

### DIFF
--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -46,6 +46,10 @@ SECTION_LABELS = {
     "discussion": "مناقشة 💬",
     "lab": "عملي 🔬",
     "field_trip": "رحلة 🚌",
+}
+
+# Arabic labels with icons for subject cards
+CARD_LABELS = {
     "syllabus": "التوصيف 📄",
     "glossary": "المفردات الدراسية 📖",
     "practical": "الواقع التطبيقي ⚙️",
@@ -127,7 +131,9 @@ async def _load_children(
                 )
                 item_id = f"{subj_id}-{sect}-{item_id}-{year_id}"
             if child_kind == "section":
-                item_label = SECTION_LABELS.get(item_label, item_label)
+                item_label = SECTION_LABELS.get(
+                    item_label, CARD_LABELS.get(item_label, item_label)
+                )
             children.append((child_kind, item_id, item_label))
     context.user_data[LAST_CHILDREN_KEY] = {
         "node_key": node_key,


### PR DESCRIPTION
## Summary
- split section labels and card labels into dedicated dictionaries
- update child translation to consult both label sets

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba09f42e0c8329bee8d4a3dd55e028