### PR TITLE
feat: separate card and section callbacks

### DIFF
--- a/tests/test_navigation_section_skip.py
+++ b/tests/test_navigation_section_skip.py
@@ -110,7 +110,7 @@ def test_single_section_does_not_skip(tmp_path):
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
-    assert "nav:section:1-theory" in buttons
+    assert "nav:sec:1-theory" in buttons
     for cat, _label in CATEGORIES:
         assert f"nav:section_option:1-theory-{cat}" not in buttons
 
@@ -141,10 +141,10 @@ def test_multiple_sections_no_skip_and_no_categories(tmp_path):
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
-    assert "nav:section:1-theory" in buttons
-    assert "nav:section:1-lab" in buttons
+    assert "nav:sec:1-theory" in buttons
+    assert "nav:sec:1-lab" in buttons
     query2 = SimpleNamespace(
-        data="nav:section:1-theory",
+        data="nav:sec:1-theory",
         message=message,
         answer=AsyncMock(),
         from_user=None,

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -225,9 +225,9 @@ def test_load_children_merges_subject_and_section(monkeypatch, navtree):
 
     children = asyncio.run(run())
     assert children == [
-        ("section", "7-theory", "نظري 📘"),
-        ("section", "7-lab", "عملي 🔬"),
-        ("section", "7-field_trip", "رحلة 🚌"),
+        ("sec", "7-theory", "نظري 📘"),
+        ("sec", "7-lab", "عملي 🔬"),
+        ("sec", "7-field_trip", "رحلة 🚌"),
     ]
 
 
@@ -280,7 +280,8 @@ def test_section_label_translation(monkeypatch, navtree, section, label):
         return await navtree._load_children(ctx, "subject", 7, user_id=None)
 
     children = asyncio.run(run())
-    assert children == [("section", f"7-{section}", label)]
+    expected_kind = "sec" if section in {"theory", "discussion", "lab", "field_trip"} else "card"
+    assert children == [(expected_kind, f"7-{section}", label)]
 
 
 def test_get_children_accepts_composite(monkeypatch):


### PR DESCRIPTION
## Summary
- distinguish card vs section nodes when building navigation tree
- handle `nav:card` callbacks to display subject cards directly
- test card callbacks and update existing tests for new prefixes

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d10600083298f3cabd0b64a7405