### PR TITLE
Separate card and section queries

### DIFF
--- a/bot/db/materials.py
+++ b/bot/db/materials.py
@@ -420,6 +420,22 @@ async def get_materials_by_category(
         return await cur.fetchall()
 
 
+async def get_materials_by_card(subject_id: int, card_code: str):
+    """Return materials for a subject card ordered by newest first."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            """
+            SELECT id, title, url, tg_storage_chat_id, tg_storage_msg_id
+            FROM materials
+            WHERE subject_id=? AND category=?
+              AND (url IS NOT NULL OR tg_storage_msg_id IS NOT NULL)
+            ORDER BY id DESC
+            """,
+            (subject_id, card_code),
+        )
+        return await cur.fetchall()
+
+
 async def has_materials_by_category(subject_id: int, section: str, category: str) -> bool:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(

--- a/bot/navigation/tree.py
+++ b/bot/navigation/tree.py
@@ -9,6 +9,7 @@ from ..db import (
     get_terms_by_level,
     get_subjects_by_level_and_term,
     get_available_sections_for_subject,
+    get_available_cards_for_subject,
     get_years_for_subject_section,
     get_lecturers_for_subject_section,
     get_lectures_by_lecturer_year,
@@ -74,6 +75,12 @@ CATEGORY_SECTIONS = {
     "skills",
     "open_source_projects",
 }
+
+async def get_sections_and_cards_for_subject(subject_id: int) -> list[str]:
+    """Return available sections and cards for a subject."""
+    sections = await get_available_sections_for_subject(subject_id)
+    cards = await get_available_cards_for_subject(subject_id)
+    return sections + cards
 
 async def get_term_menu_items(level_id: int, term_id: int):
     items = [("subjects", "عرض المواد")]
@@ -258,7 +265,7 @@ KIND_TO_LOADER: Dict[str, Loader] = {
     "level": get_terms_by_level,
     "term": get_term_menu_items,
     "term_option": get_subjects_by_level_and_term,
-    "subject": get_available_sections_for_subject,
+    "subject": get_sections_and_cards_for_subject,
     "section": get_section_menu_items,
     "section_option": get_section_option_children,
     "year": get_year_menu_items,

--- a/tests/test_navigation_cards.py
+++ b/tests/test_navigation_cards.py
@@ -36,7 +36,7 @@ def test_card_button_sends_material(tmp_path):
 
         await materials.insert_material(
             1,
-            "theory",
+            "discussion",
             "glossary",
             "glossary title",
             tg_storage_chat_id=10,

--- a/tests/test_navigation_syllabus.py
+++ b/tests/test_navigation_syllabus.py
@@ -47,7 +47,7 @@ def test_syllabus_section_sends_material(tmp_path):
             1, "lab", "lecture", "l", tg_storage_chat_id=1, tg_storage_msg_id=12
         )
         await materials.insert_material(
-            1, "theory", "syllabus", "sy", tg_storage_chat_id=9, tg_storage_msg_id=99
+            1, "discussion", "syllabus", "sy", tg_storage_chat_id=9, tg_storage_msg_id=99
         )
 
         navtree = import_module("bot.handlers.navigation_tree")

--- a/tests/test_subject_sections.py
+++ b/tests/test_subject_sections.py
@@ -40,13 +40,12 @@ def test_new_sections_returned(tmp_path):
             1, "theory", "syllabus", "syllabus title", url="http://ex.com"
         )
         sections = await subjects.get_available_sections_for_subject(1)
-        assert "theory" in sections
-        assert "syllabus" in sections
+        assert sections == ["theory"]
 
-        for cat in section_categories:
-            assert cat in sections
-
+        cards = await subjects.get_available_cards_for_subject(1)
+        for cat in section_categories + ["syllabus"]:
+            assert cat in cards
         for cat in extra_categories:
-            assert cat not in sections
+            assert cat not in cards
 
     asyncio.run(_inner())


### PR DESCRIPTION
## Summary
- exclude card categories from subject section lookup
- add helpers to fetch available cards and card materials
- load subject cards separately in navigation handler

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba13fbe878832992552c95b70b289a