### PR TITLE
Use colon-separated callback data for cards and sections

### DIFF
--- a/bot/handlers/navigation_tree.py
+++ b/bot/handlers/navigation_tree.py
@@ -106,26 +106,26 @@ async def _load_children(
         cards = [c for c in CARD_LABELS if c in children_raw]
         if len(sections) > 1:
             for sect in sections:
-                item_id = f"{ident}-{sect}"
+                item_id = f"{ident}:{sect}"
                 children.append(("sec", item_id, SECTION_LABELS[sect]))
             if "syllabus" in cards:
-                children.append(("card", f"{ident}-syllabus", CARD_LABELS["syllabus"]))
+                children.append(("card", f"{ident}:syllabus", CARD_LABELS["syllabus"]))
                 cards.remove("syllabus")
             for card in cards:
-                children.append(("card", f"{ident}-{card}", CARD_LABELS[card]))
+                children.append(("card", f"{ident}:{card}", CARD_LABELS[card]))
         elif len(sections) == 1:
             sect = sections[0]
             for filt in ("year", "lecturer"):
                 item_id = f"{ident}-{sect}-{filt}"
                 children.append(("section_option", item_id, FILTER_LABELS[filt]))
             if "syllabus" in cards:
-                children.append(("card", f"{ident}-syllabus", CARD_LABELS["syllabus"]))
+                children.append(("card", f"{ident}:syllabus", CARD_LABELS["syllabus"]))
                 cards.remove("syllabus")
             for card in cards:
-                children.append(("card", f"{ident}-{card}", CARD_LABELS[card]))
+                children.append(("card", f"{ident}:{card}", CARD_LABELS[card]))
         else:
             for card in cards:
-                children.append(("card", f"{ident}-{card}", CARD_LABELS[card]))
+                children.append(("card", f"{ident}:{card}", CARD_LABELS[card]))
     else:
         for item in children_raw:
             if (
@@ -229,7 +229,7 @@ async def _render(
 
 
 def _parse_id(value: str) -> int | tuple[int, int | str] | tuple[int, int | str, str] | str:
-    parts = value.split("-")
+    parts = value.replace(":", "-").split("-")
     parsed = [int(p) if p.isdigit() else p for p in parts]
     if len(parsed) == 1:
         return parsed[0]
@@ -320,7 +320,7 @@ async def navtree_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if data.startswith("card:"):
         ident_str = data.split(":", 1)[1]
         try:
-            subj_part, card_code = ident_str.split("-", 1)
+            subj_part, card_code = ident_str.split(":", 1)
             subj_id = int(subj_part)
         except Exception:
             subj_id = None

--- a/tests/test_navigation_cards.py
+++ b/tests/test_navigation_cards.py
@@ -60,7 +60,7 @@ def test_card_button_sends_material(tmp_path):
         message = DummyMessage()
 
         query = SimpleNamespace(
-            data="nav:card:1-glossary",
+            data="nav:card:1:glossary",
             message=message,
             answer=AsyncMock(),
             from_user=SimpleNamespace(id=1),

--- a/tests/test_navigation_section_skip.py
+++ b/tests/test_navigation_section_skip.py
@@ -112,9 +112,9 @@ def test_single_section_does_not_skip(tmp_path):
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
     assert "nav:section_option:1-theory-year" in buttons
     assert "nav:section_option:1-theory-lecturer" in buttons
-    assert "nav:sec:1-theory" not in buttons
+    assert "nav:sec:1:theory" not in buttons
     for cat, _label in CATEGORIES:
-        assert f"nav:card:1-{cat}" in buttons
+        assert f"nav:card:1:{cat}" in buttons
 
 
 def test_multiple_sections_no_skip_and_no_categories(tmp_path):
@@ -143,10 +143,10 @@ def test_multiple_sections_no_skip_and_no_categories(tmp_path):
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
-    assert "nav:sec:1-theory" in buttons
-    assert "nav:sec:1-lab" in buttons
+    assert "nav:sec:1:theory" in buttons
+    assert "nav:sec:1:lab" in buttons
     query2 = SimpleNamespace(
-        data="nav:sec:1-theory",
+        data="nav:sec:1:theory",
         message=message,
         answer=AsyncMock(),
         from_user=None,

--- a/tests/test_navigation_syllabus.py
+++ b/tests/test_navigation_syllabus.py
@@ -54,7 +54,7 @@ def test_syllabus_section_sends_material(tmp_path):
 
         ctx = SimpleNamespace(user_data={})
         children = await navtree._load_children(ctx, "subject", 1, user_id=None)
-        assert ("card", "1-syllabus", "التوصيف 📄") in children
+        assert ("card", "1:syllabus", "التوصيف 📄") in children
 
         stack = NavStack(ctx.user_data)
         stack.push(("subject", 1, "Sub1"))
@@ -66,7 +66,7 @@ def test_syllabus_section_sends_material(tmp_path):
 
         message = DummyMessage()
         query = SimpleNamespace(
-            data="card:1-syllabus",
+            data="nav:card:1:syllabus",
             message=message,
             answer=AsyncMock(),
             from_user=SimpleNamespace(id=1),

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -93,7 +93,7 @@ def test_back_from_single_section_returns_to_subject(monkeypatch, navtree):
     stack = NavStack(context.user_data)
     stack.push(("term", 1, "T1"))
     stack.push(("subject", 7, "S1"))
-    stack.push(("section", "7-only", "Only"))
+    stack.push(("section", "7:only", "Only"))
 
     query = SimpleNamespace(
         data="nav:back",
@@ -188,9 +188,9 @@ def test_parse_id_handles_composite(navtree):
     assert navtree._parse_id("5") == 5
     assert navtree._parse_id("abc") == "abc"
     assert navtree._parse_id("1-2") == (1, 2)
-    assert navtree._parse_id("123-theory") == (123, "theory")
+    assert navtree._parse_id("123:theory") == (123, "theory")
     assert navtree._parse_id("123-field_trip") == (123, "field_trip")
-    assert navtree._parse_id("12-theory-year") == (12, "theory", "year")
+    assert navtree._parse_id("12:theory:year") == (12, "theory", "year")
 
 
 def test_load_children_merges_level_and_term(monkeypatch, navtree):
@@ -225,9 +225,9 @@ def test_load_children_merges_subject_and_section(monkeypatch, navtree):
 
     children = asyncio.run(run())
     assert children == [
-        ("sec", "7-theory", "نظري 📘"),
-        ("sec", "7-lab", "عملي 🔬"),
-        ("sec", "7-field_trip", "رحلة 🚌"),
+        ("sec", "7:theory", "نظري 📘"),
+        ("sec", "7:lab", "عملي 🔬"),
+        ("sec", "7:field_trip", "رحلة 🚌"),
     ]
 
 
@@ -284,7 +284,7 @@ def test_section_label_translation(monkeypatch, navtree, section, label):
 
     children = asyncio.run(run())
     expected_kind = "sec" if section in navtree.SECTION_LABELS else "card"
-    assert (expected_kind, f"7-{section}", label) in children
+    assert (expected_kind, f"7:{section}", label) in children
 
 
 def test_subject_multi_section_layout(monkeypatch, navtree):
@@ -302,10 +302,10 @@ def test_subject_multi_section_layout(monkeypatch, navtree):
 
     children = asyncio.run(run())
     assert children == [
-        ("sec", "7-theory", navtree.SECTION_LABELS["theory"]),
-        ("sec", "7-lab", navtree.SECTION_LABELS["lab"]),
-        ("card", "7-syllabus", navtree.CARD_LABELS["syllabus"]),
-        ("card", "7-glossary", navtree.CARD_LABELS["glossary"]),
+        ("sec", "7:theory", navtree.SECTION_LABELS["theory"]),
+        ("sec", "7:lab", navtree.SECTION_LABELS["lab"]),
+        ("card", "7:syllabus", navtree.CARD_LABELS["syllabus"]),
+        ("card", "7:glossary", navtree.CARD_LABELS["glossary"]),
     ]
 
 
@@ -326,8 +326,8 @@ def test_subject_single_section_layout(monkeypatch, navtree):
     assert children == [
         ("section_option", "7-theory-year", "حسب السنة"),
         ("section_option", "7-theory-lecturer", "حسب المحاضر"),
-        ("card", "7-syllabus", navtree.CARD_LABELS["syllabus"]),
-        ("card", "7-glossary", navtree.CARD_LABELS["glossary"]),
+        ("card", "7:syllabus", navtree.CARD_LABELS["syllabus"]),
+        ("card", "7:glossary", navtree.CARD_LABELS["glossary"]),
     ]
 
 


### PR DESCRIPTION
## Summary
- encode navigation section and card buttons using `nav:sec:<subj_id>:<code>` and `nav:card:<subj_id>:<code>`
- parse colon-delimited identifiers and route card callbacks correctly
- adjust tests for updated callback formats

## Testing
- `PYTHONPATH=. pytest`
- `rg 'nav:sec:.*card' -n || true`


------
https://chatgpt.com/codex/tasks/task_e_68ba1724761083299e71b0aa11263868