### PR TITLE
Add dynamic taxonomy migration

### DIFF
--- a/database/migrations/001_dynamic_taxonomy.sql
+++ b/database/migrations/001_dynamic_taxonomy.sql
@@ -1,0 +1,122 @@
+-- Migration: dynamic taxonomy tables and schema updates
+-- Creates sections/cards/item types/hashtag aliasing and mappings
+-- Adds section_id/category_id/item_type_id/lecture_no/content_hash to materials
+-- Replaces textual section with section_id in topics and groups
+
+-- sections
+CREATE TABLE IF NOT EXISTS sections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key TEXT NOT NULL UNIQUE,
+    label_ar TEXT NOT NULL,
+    label_en TEXT NOT NULL,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER DEFAULT 0
+);
+
+-- cards (material categories/cards)
+CREATE TABLE IF NOT EXISTS cards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key TEXT NOT NULL UNIQUE,
+    label_ar TEXT NOT NULL,
+    label_en TEXT NOT NULL,
+    section_id INTEGER,
+    show_when_empty INTEGER NOT NULL DEFAULT 0,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER DEFAULT 0,
+    FOREIGN KEY (section_id) REFERENCES sections(id)
+);
+
+-- item types
+CREATE TABLE IF NOT EXISTS item_types (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key TEXT NOT NULL UNIQUE,
+    label_ar TEXT NOT NULL,
+    label_en TEXT NOT NULL,
+    requires_lecture INTEGER NOT NULL DEFAULT 0,
+    allows_year INTEGER NOT NULL DEFAULT 1,
+    allows_lecturer INTEGER NOT NULL DEFAULT 1,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER DEFAULT 0
+);
+
+-- hashtag aliases
+CREATE TABLE IF NOT EXISTS hashtag_aliases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    alias TEXT NOT NULL UNIQUE,
+    normalized TEXT NOT NULL,
+    lang TEXT
+);
+
+-- hashtag mappings
+CREATE TABLE IF NOT EXISTS hashtag_mappings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    alias_id INTEGER NOT NULL,
+    target_kind TEXT NOT NULL,
+    target_id INTEGER NOT NULL,
+    is_content_tag INTEGER NOT NULL DEFAULT 0,
+    overrides TEXT,
+    FOREIGN KEY (alias_id) REFERENCES hashtag_aliases(id)
+);
+
+-- subject section enablement
+CREATE TABLE IF NOT EXISTS subject_section_enable (
+    subject_id INTEGER NOT NULL,
+    section_id INTEGER NOT NULL,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    sort_order INTEGER DEFAULT 0,
+    PRIMARY KEY (subject_id, section_id),
+    FOREIGN KEY (subject_id) REFERENCES subjects(id),
+    FOREIGN KEY (section_id) REFERENCES sections(id)
+);
+
+-- optional: section rules
+CREATE TABLE IF NOT EXISTS section_rules (
+    section_id INTEGER PRIMARY KEY,
+    requires_lecture INTEGER NOT NULL DEFAULT 0,
+    allows_year INTEGER NOT NULL DEFAULT 1,
+    allows_lecturer INTEGER NOT NULL DEFAULT 1,
+    extra TEXT,
+    FOREIGN KEY (section_id) REFERENCES sections(id)
+);
+
+-- optional: link allowed item types per section
+CREATE TABLE IF NOT EXISTS section_item_types (
+    section_id INTEGER NOT NULL,
+    item_type_id INTEGER NOT NULL,
+    is_enabled INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (section_id, item_type_id),
+    FOREIGN KEY (section_id) REFERENCES sections(id),
+    FOREIGN KEY (item_type_id) REFERENCES item_types(id)
+);
+
+-- augment materials table
+ALTER TABLE materials ADD COLUMN section_id INTEGER;
+ALTER TABLE materials ADD COLUMN category_id INTEGER;
+ALTER TABLE materials ADD COLUMN item_type_id INTEGER;
+ALTER TABLE materials ADD COLUMN lecture_no INTEGER;
+ALTER TABLE materials ADD COLUMN content_hash TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_materials_subj_section_year_lect_cat
+ON materials(subject_id, section_id, year_id, lecturer_id, category_id);
+
+CREATE INDEX IF NOT EXISTS idx_materials_subj_section_year_lect_itemtype_lectno
+ON materials(subject_id, section_id, year_id, lecturer_id, item_type_id, lecture_no);
+
+-- topics: replace section text with section_id
+ALTER TABLE topics RENAME TO topics_old;
+CREATE TABLE topics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id INTEGER NOT NULL,
+    tg_topic_id INTEGER NOT NULL,
+    subject_id INTEGER NOT NULL,
+    section_id INTEGER,
+    FOREIGN KEY (group_id) REFERENCES groups(id),
+    FOREIGN KEY (subject_id) REFERENCES subjects(id),
+    UNIQUE (group_id, tg_topic_id)
+);
+INSERT INTO topics (id, group_id, tg_topic_id, subject_id, section_id)
+SELECT id, group_id, tg_topic_id, subject_id, NULL FROM topics_old;
+DROP TABLE topics_old;
+
+-- groups: add section_id column
+ALTER TABLE groups ADD COLUMN section_id INTEGER REFERENCES sections(id);

--- a/database/migrations/001_fix.sql
+++ b/database/migrations/001_fix.sql
@@ -1,0 +1,32 @@
+-- 001_fix.sql — complementary constraints & indices for P0.1
+-- Goal: tighten uniqueness and add read indices without table rebuilds.
+
+PRAGMA foreign_keys=ON;
+
+BEGIN;
+
+-- 1) hashtag_mappings: prevent multiple targets per alias
+CREATE UNIQUE INDEX IF NOT EXISTS ux_hashtag_mappings_alias
+ON hashtag_mappings(alias_id);
+
+-- helpful read pattern for lookups by target and content-type filter
+CREATE INDEX IF NOT EXISTS idx_hashtag_mappings_target
+ON hashtag_mappings(target_kind, target_id, is_content_tag);
+
+-- 2) hashtag_aliases: normalized uniqueness (case-insensitive)
+-- SQLite hint: COLLATE NOCASE on index to avoid duplicates like 'Slides'/'slides'
+CREATE UNIQUE INDEX IF NOT EXISTS ux_hashtag_aliases_normalized
+ON hashtag_aliases(normalized COLLATE NOCASE);
+
+-- 3) cards: speed up section-level filtering
+CREATE INDEX IF NOT EXISTS idx_cards_section
+ON cards(section_id);
+
+-- 4) subject_section_enable & section_item_types: common read paths
+CREATE INDEX IF NOT EXISTS idx_subject_section_enable_subject
+ON subject_section_enable(subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_section_item_types_item
+ON section_item_types(item_type_id);
+
+COMMIT;

--- a/database/migrations/001_notes.md
+++ b/database/migrations/001_notes.md
@@ -1,0 +1,8 @@
+# 001_fix.sql notes
+
+Adds supporting constraints and indices for migration P0.1:
+
+- Uniqueness on `hashtag_mappings.alias_id` to prevent multiple targets per alias.
+- Read indices to speed up lookup queries on mappings, cards, and section relations.
+- Case-insensitive normalized uniqueness for `hashtag_aliases`.
+- All wrapped in a transaction with `PRAGMA foreign_keys` enabled.

--- a/database/seed_dynamic_taxonomy.sql
+++ b/database/seed_dynamic_taxonomy.sql
@@ -1,0 +1,2 @@
+-- Seed data for dynamic taxonomy tables (sections, cards, item_types, hashtags).
+-- This file intentionally left blank; populate with INSERT statements as needed.


### PR DESCRIPTION
## Summary
- add migration to move taxonomy constants to database and extend materials schema
- add empty seed script for dynamic taxonomy
- add complementary indices and uniqueness constraints in 001_fix.sql with notes

## Testing
- `sqlite3 /tmp/test.db < database/init.sql`
- `sqlite3 /tmp/test.db < database/migrations/001_dynamic_taxonomy.sql`
- `sqlite3 /tmp/test.db < database/migrations/001_fix.sql`
- `sqlite3 /tmp/test.db "PRAGMA index_list('hashtag_mappings');"`
- `sqlite3 /tmp/test.db "PRAGMA index_list('hashtag_aliases');"`
- `sqlite3 /tmp/test.db "PRAGMA index_list('cards');"`
- `sqlite3 /tmp/test.db "PRAGMA index_list('subject_section_enable');"`
- `sqlite3 /tmp/test.db "PRAGMA index_list('section_item_types');"`
- `sqlite3 /tmp/test.db <<'SQL'
INSERT INTO hashtag_aliases (id, alias, normalized, lang) VALUES (1,'Slides','slides','en');
INSERT INTO hashtag_aliases (id, alias, normalized, lang) VALUES (2,'slides','slides','en');
SQL` *(fails: UNIQUE constraint)*
- `sqlite3 /tmp/test.db <<'SQL'
INSERT INTO hashtag_mappings (id, alias_id, target_kind, target_id, is_content_tag)
VALUES (1,1,'content',123,1);
INSERT INTO hashtag_mappings (id, alias_id, target_kind, target_id, is_content_tag)
VALUES (2,1,'content',124,1);
SQL` *(fails: UNIQUE constraint)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf177b99883298baec06797b36c6b