### PR TITLE
feat: add repository data access layer

### DIFF
--- a/bot/repo/__init__.py
+++ b/bot/repo/__init__.py
@@ -1,0 +1,15 @@
+"""Database repository layer.
+
+This package contains thin wrappers around the raw SQL queries used
+in the bot.  Handlers interact with the database exclusively through
+these functions which keeps the higher level logic independent from
+the underlying storage implementation.
+"""
+
+__all__ = [
+    "taxonomy",
+    "hashtags",
+    "materials",
+    "linking",
+    "rbac",
+]

--- a/bot/repo/hashtags.py
+++ b/bot/repo/hashtags.py
@@ -1,0 +1,86 @@
+"""Repository helpers for hashtag aliasing and mappings."""
+from __future__ import annotations
+
+import aiosqlite
+
+from bot.db import base
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+async def create_alias(alias: str, normalized: str, *, lang: str | None = None) -> int:
+    """Insert a new alias and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "INSERT INTO hashtag_aliases (alias, normalized, lang) VALUES (?, ?, ?)",
+            (alias, normalized, lang),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_alias(alias: str) -> tuple | None:
+    """Return alias row for *alias* or ``None`` if missing."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, alias, normalized, lang FROM hashtag_aliases WHERE alias=?",
+            (alias,),
+        )
+        return await cur.fetchone()
+
+
+async def update_alias(alias_id: int, **fields) -> None:
+    """Update an alias row with supplied *fields*."""
+    if not fields:
+        return
+    cols = ", ".join(f"{k}=?" for k in fields)
+    params = list(fields.values()) + [alias_id]
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(f"UPDATE hashtag_aliases SET {cols} WHERE id=?", params)
+        await db.commit()
+
+
+async def delete_alias(alias_id: int) -> None:
+    """Delete alias with id *alias_id*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("DELETE FROM hashtag_aliases WHERE id=?", (alias_id,))
+        await db.commit()
+
+# ---------------------------------------------------------------------------
+# Mappings
+# ---------------------------------------------------------------------------
+async def create_mapping(alias_id: int, target_kind: str, target_id: int, *,
+                         is_content_tag: bool = False,
+                         overrides: str | None = None) -> int:
+    """Insert a mapping from an alias to a target entity."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO hashtag_mappings
+                (alias_id, target_kind, target_id, is_content_tag, overrides)
+                VALUES (?, ?, ?, ?, ?)""",
+            (alias_id, target_kind, target_id, int(is_content_tag), overrides),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_mappings_for_alias(alias: str) -> list[tuple]:
+    """Return mapping rows for *alias* string."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """SELECT m.id, a.alias, m.target_kind, m.target_id, m.is_content_tag, m.overrides
+                FROM hashtag_mappings m
+                JOIN hashtag_aliases a ON a.id = m.alias_id
+                WHERE a.alias=?""",
+            (alias,),
+        )
+        return await cur.fetchall()
+
+
+async def lookup_targets(alias: str) -> list[tuple[str, int]]:
+    """Return ``(target_kind, target_id)`` pairs for *alias*.
+
+    The lookup first resolves the alias then returns all mapped targets.
+    """
+    rows = await get_mappings_for_alias(alias)
+    return [(r[2], r[3]) for r in rows]

--- a/bot/repo/linking.py
+++ b/bot/repo/linking.py
@@ -1,0 +1,75 @@
+"""Repository helpers for linking Telegram entities to subjects and sections."""
+from __future__ import annotations
+
+import aiosqlite
+
+from bot.db import base
+
+async def upsert_group(tg_chat_id: int, title: str,
+                       *, level_id: int | None = None,
+                       term_id: int | None = None,
+                       section_id: int | None = None) -> int:
+    """Insert or update a group record and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO groups (tg_chat_id, title, level_id, term_id, section_id)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(tg_chat_id) DO UPDATE SET
+                    title=excluded.title,
+                    level_id=excluded.level_id,
+                    term_id=excluded.term_id,
+                    section_id=excluded.section_id""",
+            (tg_chat_id, title, level_id, term_id, section_id),
+        )
+        await db.commit()
+        if cur.lastrowid:
+            return cur.lastrowid
+        # On conflict SQLite returns 0; fetch existing id
+        cur = await db.execute("SELECT id FROM groups WHERE tg_chat_id=?", (tg_chat_id,))
+        row = await cur.fetchone()
+        assert row is not None
+        return row[0]
+
+
+async def get_group(tg_chat_id: int) -> tuple | None:
+    """Return group row for *tg_chat_id* or ``None``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, tg_chat_id, title, level_id, term_id, section_id FROM groups WHERE tg_chat_id=?",
+            (tg_chat_id,),
+        )
+        return await cur.fetchone()
+
+
+async def upsert_topic(group_id: int, tg_topic_id: int, subject_id: int,
+                       *, section_id: int | None = None) -> int:
+    """Insert or update a topic linking to a subject/section."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO topics (group_id, tg_topic_id, subject_id, section_id)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(group_id, tg_topic_id) DO UPDATE SET
+                    subject_id=excluded.subject_id,
+                    section_id=excluded.section_id""",
+            (group_id, tg_topic_id, subject_id, section_id),
+        )
+        await db.commit()
+        if cur.lastrowid:
+            return cur.lastrowid
+        cur = await db.execute(
+            "SELECT id FROM topics WHERE group_id=? AND tg_topic_id=?",
+            (group_id, tg_topic_id),
+        )
+        row = await cur.fetchone()
+        assert row is not None
+        return row[0]
+
+
+async def get_topic(group_id: int, tg_topic_id: int) -> tuple | None:
+    """Return topic row for identifiers."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, group_id, tg_topic_id, subject_id, section_id FROM topics WHERE group_id=? AND tg_topic_id=?",
+            (group_id, tg_topic_id),
+        )
+        return await cur.fetchone()

--- a/bot/repo/materials.py
+++ b/bot/repo/materials.py
@@ -1,0 +1,109 @@
+"""Repository helpers for material records.
+
+These functions expose a minimal CRUD interface for the ``materials``
+table using the new dynamic-taxonomy columns ``section_id``,
+``category_id`` and ``item_type_id``.  Only a small subset of the
+production queries is implemented which is sufficient for unit tests
+and for handlers that merely need basic persistence.
+"""
+from __future__ import annotations
+
+import aiosqlite
+
+from bot.db import base
+
+async def insert_material(
+    subject_id: int,
+    section_id: int | None,
+    category_id: int | None,
+    item_type_id: int | None,
+    title: str,
+    *,
+    url: str | None = None,
+    year_id: int | None = None,
+    lecturer_id: int | None = None,
+    lecture_no: int | None = None,
+    content_hash: str | None = None,
+    tg_storage_chat_id: int | None = None,
+    tg_storage_msg_id: int | None = None,
+    file_unique_id: str | None = None,
+    source_chat_id: int | None = None,
+    source_topic_id: int | None = None,
+    source_message_id: int | None = None,
+    created_by_admin_id: int | None = None,
+) -> int:
+    """Insert a material record and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO materials (
+                    subject_id, section_id, category_id, item_type_id, title, url,
+                    year_id, lecturer_id, lecture_no, content_hash,
+                    tg_storage_chat_id, tg_storage_msg_id, file_unique_id,
+                    source_chat_id, source_topic_id, source_message_id,
+                    created_by_admin_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                subject_id,
+                section_id,
+                category_id,
+                item_type_id,
+                title,
+                url,
+                year_id,
+                lecturer_id,
+                lecture_no,
+                content_hash,
+                tg_storage_chat_id,
+                tg_storage_msg_id,
+                file_unique_id,
+                source_chat_id,
+                source_topic_id,
+                source_message_id,
+                created_by_admin_id,
+            ),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_material(material_id: int) -> tuple | None:
+    """Return material row for *material_id* or ``None``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT * FROM materials WHERE id=?",
+            (material_id,),
+        )
+        return await cur.fetchone()
+
+
+async def update_material_storage(
+    material_id: int,
+    chat_id: int,
+    msg_id: int,
+    *,
+    file_unique_id: str | None = None,
+) -> None:
+    """Update storage chat/message identifiers for a material."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(
+            "UPDATE materials SET tg_storage_chat_id=?, tg_storage_msg_id=?, file_unique_id=? WHERE id=?",
+            (chat_id, msg_id, file_unique_id, material_id),
+        )
+        await db.commit()
+
+
+async def delete_material(material_id: int) -> None:
+    """Remove a material record."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("DELETE FROM materials WHERE id=?", (material_id,))
+        await db.commit()
+
+
+async def find_by_hash(content_hash: str) -> tuple | None:
+    """Return the first material row matching *content_hash*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT * FROM materials WHERE content_hash=?",
+            (content_hash,),
+        )
+        return await cur.fetchone()

--- a/bot/repo/rbac.py
+++ b/bot/repo/rbac.py
@@ -1,0 +1,67 @@
+"""Repository utilities for role based access control (RBAC)."""
+from __future__ import annotations
+
+import aiosqlite
+
+from bot.db import base
+
+async def create_admin(tg_user_id: int, name: str, role: str,
+                       permissions_mask: int,
+                       *, level_scope: str = "all",
+                       is_active: bool = True) -> int:
+    """Insert an admin account and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO admins (tg_user_id, name, role, permissions_mask, level_scope, is_active)
+                VALUES (?, ?, ?, ?, ?, ?)""",
+            (tg_user_id, name, role, permissions_mask, level_scope, int(is_active)),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_admin_by_user_id(tg_user_id: int) -> tuple | None:
+    """Return admin row for Telegram ``user_id`` or ``None``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, tg_user_id, name, role, permissions_mask, level_scope, is_active FROM admins WHERE tg_user_id=?",
+            (tg_user_id,),
+        )
+        return await cur.fetchone()
+
+
+async def set_admin_active(tg_user_id: int, is_active: bool) -> None:
+    """Enable or disable an admin account."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(
+            "UPDATE admins SET is_active=? WHERE tg_user_id=?",
+            (int(is_active), tg_user_id),
+        )
+        await db.commit()
+
+
+async def update_permissions(tg_user_id: int, permissions_mask: int) -> None:
+    """Set the permissions mask for an admin."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(
+            "UPDATE admins SET permissions_mask=? WHERE tg_user_id=?",
+            (permissions_mask, tg_user_id),
+        )
+        await db.commit()
+
+
+async def has_permissions(tg_user_id: int, mask: int) -> bool:
+    """Return ``True`` if admin ``tg_user_id`` has all permissions in *mask*.
+
+    The check verifies that the admin exists, is active and that the
+    provided mask bits are present in the stored ``permissions_mask``.
+    """
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT permissions_mask, is_active FROM admins WHERE tg_user_id=?",
+            (tg_user_id,),
+        )
+        row = await cur.fetchone()
+        if row is None or not row[1]:
+            return False
+        return (row[0] & mask) == mask

--- a/bot/repo/taxonomy.py
+++ b/bot/repo/taxonomy.py
@@ -1,0 +1,214 @@
+"""Helpers for managing the dynamic taxonomy tables.
+
+The repository exposes CRUD operations for the following tables:
+
+* ``sections``
+* ``cards`` (material categories)
+* ``item_types``
+* ``subject_section_enable``
+
+Each function returns basic Python types (``int`` ids or ``tuple`` rows)
+so that higher level code can remain agnostic of the underlying SQL
+implementation.  All operations are asynchronous and use the global
+``DB_PATH`` from :mod:`bot.db.base`.
+"""
+from __future__ import annotations
+
+import aiosqlite
+
+from bot.db import base
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+async def create_section(key: str, label_ar: str, label_en: str,
+                        *, is_enabled: bool = True, sort_order: int = 0) -> int:
+    """Insert a new section and return its database id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO sections (key, label_ar, label_en, is_enabled, sort_order)
+                VALUES (?, ?, ?, ?, ?)""",
+            (key, label_ar, label_en, int(is_enabled), sort_order),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_section(key: str) -> tuple | None:
+    """Return the section row for *key* or ``None`` if not found."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, key, label_ar, label_en, is_enabled, sort_order FROM sections WHERE key=?",
+            (key,),
+        )
+        return await cur.fetchone()
+
+
+async def update_section(section_id: int, **fields) -> None:
+    """Update a section row using keyword *fields*.
+
+    Only supplied fields are updated.  Allowed keys: ``key``, ``label_ar``,
+    ``label_en``, ``is_enabled`` and ``sort_order``.
+    """
+    if not fields:
+        return
+    cols = ", ".join(f"{k}=?" for k in fields)
+    params = list(fields.values()) + [section_id]
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(f"UPDATE sections SET {cols} WHERE id=?", params)
+        await db.commit()
+
+
+async def delete_section(section_id: int) -> None:
+    """Delete section with *section_id*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("DELETE FROM sections WHERE id=?", (section_id,))
+        await db.commit()
+
+# ---------------------------------------------------------------------------
+# Cards (material categories)
+# ---------------------------------------------------------------------------
+async def create_card(key: str, label_ar: str, label_en: str, *,
+                      section_id: int | None = None,
+                      show_when_empty: bool = False,
+                      is_enabled: bool = True,
+                      sort_order: int = 0) -> int:
+    """Insert a card (material category) and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO cards
+                (key, label_ar, label_en, section_id, show_when_empty, is_enabled, sort_order)
+                VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                key,
+                label_ar,
+                label_en,
+                section_id,
+                int(show_when_empty),
+                int(is_enabled),
+                sort_order,
+            ),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_card(key: str) -> tuple | None:
+    """Return card row for *key* or ``None``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, key, label_ar, label_en, section_id, show_when_empty, is_enabled, sort_order FROM cards WHERE key=?",
+            (key,),
+        )
+        return await cur.fetchone()
+
+
+async def update_card(card_id: int, **fields) -> None:
+    """Update card row with given *fields*.
+
+    Allowed keys: ``key``, ``label_ar``, ``label_en``, ``section_id``,
+    ``show_when_empty``, ``is_enabled`` and ``sort_order``.
+    """
+    if not fields:
+        return
+    cols = ", ".join(f"{k}=?" for k in fields)
+    params = list(fields.values()) + [card_id]
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(f"UPDATE cards SET {cols} WHERE id=?", params)
+        await db.commit()
+
+
+async def delete_card(card_id: int) -> None:
+    """Delete card with *card_id*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("DELETE FROM cards WHERE id=?", (card_id,))
+        await db.commit()
+
+# ---------------------------------------------------------------------------
+# Item types
+# ---------------------------------------------------------------------------
+async def create_item_type(key: str, label_ar: str, label_en: str, *,
+                           requires_lecture: bool = False,
+                           allows_year: bool = True,
+                           allows_lecturer: bool = True,
+                           is_enabled: bool = True,
+                           sort_order: int = 0) -> int:
+    """Insert an item type and return its id."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            """INSERT INTO item_types
+                (key, label_ar, label_en, requires_lecture, allows_year, allows_lecturer, is_enabled, sort_order)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                key,
+                label_ar,
+                label_en,
+                int(requires_lecture),
+                int(allows_year),
+                int(allows_lecturer),
+                int(is_enabled),
+                sort_order,
+            ),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+async def get_item_type(key: str) -> tuple | None:
+    """Return item type row for *key* or ``None``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT id, key, label_ar, label_en, requires_lecture, allows_year, allows_lecturer, is_enabled, sort_order FROM item_types WHERE key=?",
+            (key,),
+        )
+        return await cur.fetchone()
+
+
+async def update_item_type(item_type_id: int, **fields) -> None:
+    """Update an item type row with *fields*.
+
+    Allowed keys: ``key``, ``label_ar``, ``label_en``, ``requires_lecture``,
+    ``allows_year``, ``allows_lecturer``, ``is_enabled`` and ``sort_order``.
+    """
+    if not fields:
+        return
+    cols = ", ".join(f"{k}=?" for k in fields)
+    params = list(fields.values()) + [item_type_id]
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(f"UPDATE item_types SET {cols} WHERE id=?", params)
+        await db.commit()
+
+
+async def delete_item_type(item_type_id: int) -> None:
+    """Delete item type with *item_type_id*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("DELETE FROM item_types WHERE id=?", (item_type_id,))
+        await db.commit()
+
+# ---------------------------------------------------------------------------
+# Subject section enablement
+# ---------------------------------------------------------------------------
+async def set_subject_section_enable(subject_id: int, section_id: int,
+                                    *, is_enabled: bool = True,
+                                    sort_order: int = 0) -> None:
+    """Upsert ``subject_section_enable`` row for *subject_id*/*section_id*."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute(
+            """INSERT INTO subject_section_enable
+                (subject_id, section_id, is_enabled, sort_order)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(subject_id, section_id)
+                DO UPDATE SET is_enabled=excluded.is_enabled, sort_order=excluded.sort_order""",
+            (subject_id, section_id, int(is_enabled), sort_order),
+        )
+        await db.commit()
+
+
+async def get_enabled_sections_for_subject(subject_id: int) -> list[tuple]:
+    """Return enabled sections for *subject_id* ordered by ``sort_order``."""
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        cur = await db.execute(
+            "SELECT section_id, is_enabled, sort_order FROM subject_section_enable WHERE subject_id=? ORDER BY sort_order",
+            (subject_id,),
+        )
+        return await cur.fetchall()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,131 @@
+import asyncio
+from pathlib import Path
+import sys
+import os
+
+import aiosqlite
+import pytest
+
+# Ensure repository root is on the import path so ``bot`` package is found
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+# Provide dummy environment variables required by bot.config when importing
+os.environ.setdefault("BOT_TOKEN", "test")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+os.environ.setdefault("ADMIN_USER_IDS", "1")
+os.environ.setdefault("GROUP_ID", "1")
+
+from bot.db import base
+
+@pytest.fixture()
+def repo_db(tmp_path, monkeypatch):
+    """Create a temporary sqlite database for repository tests."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(base, "DB_PATH", str(db_path))
+
+    async def setup() -> None:
+        async with aiosqlite.connect(str(db_path)) as db:
+            await db.executescript(
+                """
+                CREATE TABLE sections (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE,
+                    label_ar TEXT,
+                    label_en TEXT,
+                    is_enabled INTEGER,
+                    sort_order INTEGER
+                );
+                CREATE TABLE cards (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE,
+                    label_ar TEXT,
+                    label_en TEXT,
+                    section_id INTEGER,
+                    show_when_empty INTEGER,
+                    is_enabled INTEGER,
+                    sort_order INTEGER
+                );
+                CREATE TABLE item_types (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE,
+                    label_ar TEXT,
+                    label_en TEXT,
+                    requires_lecture INTEGER,
+                    allows_year INTEGER,
+                    allows_lecturer INTEGER,
+                    is_enabled INTEGER,
+                    sort_order INTEGER
+                );
+                CREATE TABLE subject_section_enable (
+                    subject_id INTEGER,
+                    section_id INTEGER,
+                    is_enabled INTEGER,
+                    sort_order INTEGER,
+                    PRIMARY KEY(subject_id, section_id)
+                );
+                CREATE TABLE hashtag_aliases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    alias TEXT UNIQUE,
+                    normalized TEXT,
+                    lang TEXT
+                );
+                CREATE TABLE hashtag_mappings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    alias_id INTEGER,
+                    target_kind TEXT,
+                    target_id INTEGER,
+                    is_content_tag INTEGER,
+                    overrides TEXT
+                );
+                CREATE TABLE materials (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    subject_id INTEGER NOT NULL,
+                    section_id INTEGER,
+                    category_id INTEGER,
+                    item_type_id INTEGER,
+                    title TEXT NOT NULL,
+                    url TEXT,
+                    year_id INTEGER,
+                    lecturer_id INTEGER,
+                    lecture_no INTEGER,
+                    content_hash TEXT,
+                    tg_storage_chat_id INTEGER,
+                    tg_storage_msg_id INTEGER,
+                    file_unique_id TEXT,
+                    source_chat_id INTEGER,
+                    source_topic_id INTEGER,
+                    source_message_id INTEGER,
+                    created_by_admin_id INTEGER
+                );
+                CREATE TABLE groups (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tg_chat_id INTEGER UNIQUE NOT NULL,
+                    title TEXT,
+                    level_id INTEGER,
+                    term_id INTEGER,
+                    section_id INTEGER
+                );
+                CREATE TABLE topics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    group_id INTEGER NOT NULL,
+                    tg_topic_id INTEGER NOT NULL,
+                    subject_id INTEGER NOT NULL,
+                    section_id INTEGER,
+                    UNIQUE(group_id, tg_topic_id)
+                );
+                CREATE TABLE admins (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tg_user_id INTEGER UNIQUE,
+                    name TEXT,
+                    role TEXT,
+                    permissions_mask INTEGER,
+                    level_scope TEXT,
+                    is_active INTEGER
+                );
+                """
+            )
+            await db.commit()
+
+    asyncio.run(setup())
+    return str(db_path)

--- a/tests/test_repo_hashtags.py
+++ b/tests/test_repo_hashtags.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from bot.repo import hashtags
+
+
+def test_alias_crud(repo_db):
+    aid = asyncio.run(hashtags.create_alias("math", "math"))
+    row = asyncio.run(hashtags.get_alias("math"))
+    assert row[0] == aid
+    asyncio.run(hashtags.update_alias(aid, normalized="maths"))
+    row = asyncio.run(hashtags.get_alias("math"))
+    assert row[2] == "maths"
+    asyncio.run(hashtags.delete_alias(aid))
+    assert asyncio.run(hashtags.get_alias("math")) is None
+
+
+def test_mapping_and_lookup(repo_db):
+    aid = asyncio.run(hashtags.create_alias("physics", "physics"))
+    mid = asyncio.run(hashtags.create_mapping(aid, "subject", 5))
+    rows = asyncio.run(hashtags.get_mappings_for_alias("physics"))
+    assert rows[0][0] == mid
+    targets = asyncio.run(hashtags.lookup_targets("physics"))
+    assert targets == [("subject", 5)]

--- a/tests/test_repo_linking.py
+++ b/tests/test_repo_linking.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from bot.repo import linking
+
+
+def test_group_crud(repo_db):
+    gid = asyncio.run(linking.upsert_group(123, "Group"))
+    row = asyncio.run(linking.get_group(123))
+    assert row[0] == gid
+    asyncio.run(linking.upsert_group(123, "Group2", level_id=1))
+    row = asyncio.run(linking.get_group(123))
+    assert row[3] == 1
+
+
+def test_topic_crud(repo_db):
+    gid = asyncio.run(linking.upsert_group(456, "G"))
+    tid = asyncio.run(linking.upsert_topic(gid, 789, 3, section_id=2))
+    row = asyncio.run(linking.get_topic(gid, 789))
+    assert row[0] == tid
+    asyncio.run(linking.upsert_topic(gid, 789, 4, section_id=1))
+    row = asyncio.run(linking.get_topic(gid, 789))
+    assert row[3] == 4 and row[4] == 1

--- a/tests/test_repo_materials.py
+++ b/tests/test_repo_materials.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from bot.repo import materials, taxonomy
+
+
+def test_materials_crud(repo_db):
+    sid = asyncio.run(taxonomy.create_section("theory", "نظري", "Theory"))
+    cid = asyncio.run(taxonomy.create_card("lecture", "محاضرة", "Lecture", section_id=sid))
+    iid = asyncio.run(taxonomy.create_item_type("file", "ملف", "File"))
+    mid = asyncio.run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=cid,
+            item_type_id=iid,
+            title="Intro",
+            content_hash="abc",
+        )
+    )
+    row = asyncio.run(materials.get_material(mid))
+    assert row[0] == mid
+    asyncio.run(materials.update_material_storage(mid, 10, 20, file_unique_id="x"))
+    row = asyncio.run(materials.get_material(mid))
+    assert row[11] == 10 and row[12] == 20 and row[13] == "x"
+    found = asyncio.run(materials.find_by_hash("abc"))
+    assert found[0] == mid
+    asyncio.run(materials.delete_material(mid))
+    assert asyncio.run(materials.get_material(mid)) is None

--- a/tests/test_repo_rbac.py
+++ b/tests/test_repo_rbac.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from bot.repo import rbac
+
+
+def test_rbac(repo_db):
+    aid = asyncio.run(rbac.create_admin(1, "Admin", "owner", 0b11))
+    row = asyncio.run(rbac.get_admin_by_user_id(1))
+    assert row[0] == aid
+    assert asyncio.run(rbac.has_permissions(1, 0b01)) is True
+    asyncio.run(rbac.update_permissions(1, 0b10))
+    assert asyncio.run(rbac.has_permissions(1, 0b01)) is False
+    asyncio.run(rbac.set_admin_active(1, False))
+    assert asyncio.run(rbac.has_permissions(1, 0b10)) is False

--- a/tests/test_repo_taxonomy.py
+++ b/tests/test_repo_taxonomy.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from bot.repo import taxonomy
+
+
+def test_section_crud(repo_db):
+    sid = asyncio.run(taxonomy.create_section("theory", "نظري", "Theory"))
+    row = asyncio.run(taxonomy.get_section("theory"))
+    assert row[0] == sid
+    asyncio.run(taxonomy.update_section(sid, label_en="Theory Updated"))
+    row = asyncio.run(taxonomy.get_section("theory"))
+    assert row[3] == "Theory Updated"
+    asyncio.run(taxonomy.delete_section(sid))
+    assert asyncio.run(taxonomy.get_section("theory")) is None
+
+
+def test_card_crud(repo_db):
+    section_id = asyncio.run(taxonomy.create_section("lab", "عملي", "Lab"))
+    cid = asyncio.run(taxonomy.create_card("slides", "سلايدات", "Slides", section_id=section_id))
+    row = asyncio.run(taxonomy.get_card("slides"))
+    assert row[0] == cid
+    asyncio.run(taxonomy.update_card(cid, label_en="Slides Updated"))
+    row = asyncio.run(taxonomy.get_card("slides"))
+    assert row[3] == "Slides Updated"
+    asyncio.run(taxonomy.delete_card(cid))
+    assert asyncio.run(taxonomy.get_card("slides")) is None
+
+
+def test_item_type_crud(repo_db):
+    iid = asyncio.run(taxonomy.create_item_type("pdf", "بي دي اف", "PDF", requires_lecture=True))
+    row = asyncio.run(taxonomy.get_item_type("pdf"))
+    assert row[0] == iid
+    asyncio.run(taxonomy.update_item_type(iid, label_en="PDF Updated"))
+    row = asyncio.run(taxonomy.get_item_type("pdf"))
+    assert row[3] == "PDF Updated"
+    asyncio.run(taxonomy.delete_item_type(iid))
+    assert asyncio.run(taxonomy.get_item_type("pdf")) is None
+
+
+def test_subject_section_enable(repo_db):
+    sid = asyncio.run(taxonomy.create_section("disc", "نقاش", "Discussion"))
+    asyncio.run(taxonomy.set_subject_section_enable(1, sid, sort_order=2))
+    rows = asyncio.run(taxonomy.get_enabled_sections_for_subject(1))
+    assert rows == [(sid, 1, 2)]


### PR DESCRIPTION
## Summary
- add `bot.repo` package with CRUD helpers for taxonomy, hashtags, materials, linking and RBAC tables
- document repository functions and ensure handlers can access DB through this layer
- provide unit tests exercising each repository module using a temporary SQLite database

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8a51ea48329a86e7bb4a4259b62