### PR TITLE
feat: dynamic navigation caching

### DIFF
--- a/bot/config/config.py
+++ b/bot/config/config.py
@@ -61,7 +61,7 @@ class Config:
 
         version = os.getenv("COMMIT_SHA", "dev")
         start_time = datetime.now()
-        per_page = cls._to_int("PER_PAGE", required=False) or 8
+        per_page = cls._to_int("PER_PAGE", required=False) or 12
         nav_tree_enabled = cls._to_bool("NAV_TREE_ENABLED")
         nav_tree_shadow = cls._to_bool("NAV_TREE_SHADOW")
 

--- a/tests/test_nav_stack.py
+++ b/tests/test_nav_stack.py
@@ -27,3 +27,18 @@ def test_nav_stack_basic_operations():
     assert stack.pop() is None
     assert stack.peek() is None
     assert stack.path_text() == ""
+
+
+def test_nav_stack_clears_on_bump():
+    user_data = {}
+    stack = NavStack(user_data, bump=1)
+    stack.push(("level", 1, "L1"))
+
+    # Reinitialising with same bump preserves stack
+    stack = NavStack(user_data, bump=1)
+    assert stack.path_text() == "L1"
+
+    # Different bump clears stored path
+    stack = NavStack(user_data, bump=2)
+    assert stack.path_text() == ""
+    assert user_data["nav_stack"] == []


### PR DESCRIPTION
## Summary
- add global bump-aware cache for navigation tree
- reset navigation stack when configuration updates occur
- default paging increased to 12 items per page

## Testing
- `pytest tests/test_nav_stack.py tests/test_navigation_tree.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'trio'; sqlite3.OperationalError: no such table: hashtag_mappings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff3a1d008329ba5ff041a653f005