### PR TITLE
Add placeholder owner setup wizard handlers

### DIFF
--- a/bot/handlers/setup_wizard.py
+++ b/bot/handlers/setup_wizard.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from telegram import Update
+from telegram.ext import ContextTypes
+
+async def setup_wizard_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "🛠️ أوامر الإعداد التفاعلي غير متوفرة بعد.\n"
+        "سيتم تطوير واجهة المعالج لاحقًا."
+    )
+
+async def add_section(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ لم يتم تنفيذ إضافة قسم بعد.")
+
+async def add_card(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ لم يتم تنفيذ إضافة بطاقة بعد.")
+
+async def add_type(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ لم يتم تنفيذ إضافة نوع بعد.")
+
+async def add_alias(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ لم يتم تنفيذ إضافة مرادف بعد.")
+
+async def undo_last(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ التراجع غير متاح حاليًا.")
+
+async def show_audit_log(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("⚠️ سجل التدقيق غير متاح بعد.")


### PR DESCRIPTION
## Summary
- add stub handlers for owner setup wizard actions (section/card/type/alias)

## Testing
- `pytest` *(fails: ModuleNotFoundError for trio, sqlite3 operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be00dfba2083299b2d90dd066b5a94