### PR TITLE
feat: add role based access control

### DIFF
--- a/bot/handlers/rbac.py
+++ b/bot/handlers/rbac.py
@@ -1,0 +1,88 @@
+"""Command handlers for RBAC management.
+
+These handlers provide very small wrappers around repository functions to
+manage roles and broadcast messages.  They are intentionally simple to keep the
+focus on repository behaviour, which is where most logic resides."""
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import CommandHandler, ContextTypes
+
+from bot.repo import rbac
+
+
+async def create_role_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.effective_message.reply_text("Usage: /role_create <name> [tag1,tag2]")
+        return
+    name = context.args[0]
+    tags = context.args[1].split(",") if len(context.args) > 1 else []
+    role_id = await rbac.create_role(name, tags)
+    await update.effective_message.reply_text(f"Created role {role_id}")
+
+
+async def assign_role_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) < 2:
+        await update.effective_message.reply_text("Usage: /role_assign <user_id> <role_id>")
+        return
+    user_id, role_id = map(int, context.args[:2])
+    await rbac.assign_role(user_id, role_id)
+    await update.effective_message.reply_text("Role assigned")
+
+
+async def revoke_role_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) < 2:
+        await update.effective_message.reply_text("Usage: /role_revoke <user_id> <role_id>")
+        return
+    user_id, role_id = map(int, context.args[:2])
+    await rbac.revoke_role(user_id, role_id)
+    await update.effective_message.reply_text("Role revoked")
+
+
+async def set_perm_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) < 2:
+        await update.effective_message.reply_text(
+            "Usage: /role_perm <role_id> <permission_key> [scope_json]"
+        )
+        return
+    role_id = int(context.args[0])
+    permission_key = context.args[1]
+    scope = None
+    if len(context.args) > 2:
+        try:
+            import json
+
+            scope = json.loads(" ".join(context.args[2:]))
+        except Exception:
+            await update.effective_message.reply_text("Invalid JSON scope")
+            return
+    await rbac.set_permission(role_id, permission_key, scope)
+    await update.effective_message.reply_text("Permission set")
+
+
+async def broadcast_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if len(context.args) < 2:
+        await update.effective_message.reply_text(
+            "Usage: /role_broadcast <tag> <message>"
+        )
+        return
+    tag = context.args[0]
+    message = " ".join(context.args[1:])
+
+    async def _send(uid: int, text: str) -> None:
+        await context.bot.send_message(uid, text)
+
+    count = await rbac.broadcast(tag, message, _send)
+    await update.effective_message.reply_text(f"Broadcast sent to {count} users")
+
+
+rbac_handlers = [
+    CommandHandler("role_create", create_role_cmd),
+    CommandHandler("role_assign", assign_role_cmd),
+    CommandHandler("role_revoke", revoke_role_cmd),
+    CommandHandler("role_perm", set_perm_cmd),
+    CommandHandler("role_broadcast", broadcast_cmd),
+]
+
+
+__all__ = ["rbac_handlers"]

--- a/database/migrations/003_rbac.sql
+++ b/database/migrations/003_rbac.sql
@@ -1,0 +1,21 @@
+CREATE TABLE roles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    tags TEXT,
+    is_enabled INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE role_permissions (
+    role_id INTEGER NOT NULL,
+    permission_key TEXT NOT NULL,
+    scope TEXT,
+    PRIMARY KEY (role_id, permission_key),
+    FOREIGN KEY (role_id) REFERENCES roles(id)
+);
+
+CREATE TABLE user_roles (
+    user_id INTEGER NOT NULL,
+    role_id INTEGER NOT NULL,
+    PRIMARY KEY (user_id, role_id),
+    FOREIGN KEY (role_id) REFERENCES roles(id)
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,9 +123,32 @@ def repo_db(tmp_path, monkeypatch):
                     level_scope TEXT,
                     is_active INTEGER
                 );
+                CREATE TABLE roles (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    tags TEXT,
+                    is_enabled INTEGER
+                );
+                CREATE TABLE role_permissions (
+                    role_id INTEGER,
+                    permission_key TEXT,
+                    scope TEXT,
+                    PRIMARY KEY(role_id, permission_key)
+                );
+                CREATE TABLE user_roles (
+                    user_id INTEGER,
+                    role_id INTEGER,
+                    PRIMARY KEY(user_id, role_id)
+                );
                 """
             )
             await db.commit()
 
     asyncio.run(setup())
     return str(db_path)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Force anyio tests to use the asyncio backend."""
+    return "asyncio"

--- a/tests/test_exam_ingestion.py
+++ b/tests/test_exam_ingestion.py
@@ -20,7 +20,7 @@ def anyio_backend():
     ("#نموذج_النصفي\n#1446", "exam_mid"),
     ("#نموذج_النهائي\n#1446", "exam_final"),
 ])
-async def test_exam_ingestion(tag, expected_category, monkeypatch):
+async def test_exam_ingestion(tag, expected_category, monkeypatch, repo_db):
     insert_calls = []
     attach_calls = []
 

--- a/tests/test_single_hashtag_ingestion.py
+++ b/tests/test_single_hashtag_ingestion.py
@@ -69,7 +69,7 @@ async def _prepare(monkeypatch, binding):
     return insert_calls, attach_calls, sent_msgs, context
 
 
-async def test_single_card_in_topic(monkeypatch):
+async def test_single_card_in_topic(monkeypatch, repo_db):
     binding = {333: {"subject_id": 1, "section": "theory", "subject_name": "sub"}}
     insert_calls, attach_calls, _, context = await _prepare(monkeypatch, binding)
 
@@ -92,7 +92,7 @@ async def test_single_card_in_topic(monkeypatch):
     assert attach_calls == [(99, 10, "pending")]
 
 
-async def test_single_card_general_chat_without_binding(monkeypatch):
+async def test_single_card_general_chat_without_binding(monkeypatch, repo_db):
     binding = {}
     insert_calls, attach_calls, sent_msgs, context = await _prepare(monkeypatch, binding)
 
@@ -116,7 +116,7 @@ async def test_single_card_general_chat_without_binding(monkeypatch):
     assert sent_msgs and "يُرجى النشر داخل موضوع المادة الصحيح" in sent_msgs[0]
 
 
-async def test_single_card_general_chat_with_binding(monkeypatch):
+async def test_single_card_general_chat_with_binding(monkeypatch, repo_db):
     binding = {0: {"subject_id": 1, "section": None, "subject_name": "sub"}}
     insert_calls, attach_calls, _, context = await _prepare(monkeypatch, binding)
 

--- a/tests/test_term_resource_ingestion.py
+++ b/tests/test_term_resource_ingestion.py
@@ -136,7 +136,7 @@ async def test_term_resource_unknown_chat_autoregisters(monkeypatch, seed_terms)
 
 
 @pytest.mark.anyio
-async def test_misc_term_resource_ingestion(monkeypatch):
+async def test_misc_term_resource_ingestion(monkeypatch, repo_db):
     """Ensure files tagged with #misc get stored as miscellaneous resources."""
 
     calls = []


### PR DESCRIPTION
## Summary
- introduce roles/permissions schema and migration
- add repository utilities for roles, permissions, broadcasts
- expose basic RBAC command handlers and tests

## Testing
- `pytest` *(fails: test_exam_ingestion, test_hashtags, test_navigation_cards, test_navigation_categories, test_single_hashtag_ingestion, test_term_resource_ingestion)*
- `pytest tests/test_repo_rbac.py`

------
https://chatgpt.com/codex/tasks/task_e_68be040534808329838d7d3b244d9dc0