### PR TITLE
feat: support follow-chain ingestion

### DIFF
--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -9,16 +9,27 @@ async def insert_ingestion(
     status: str = "pending",
     action: str = "add",
     file_unique_id: str | None = None,
+    chain_id: int | None = None,
+    parent_ingestion_id: int | None = None,
 ) -> int:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(
             """
             INSERT INTO ingestions (
-                tg_message_id, admin_id, status, action, file_unique_id
+                tg_message_id, admin_id, status, action, file_unique_id,
+                chain_id, parent_ingestion_id
             )
-            VALUES (?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (tg_message_id, admin_id, status, action, file_unique_id),
+            (
+                tg_message_id,
+                admin_id,
+                status,
+                action,
+                file_unique_id,
+                chain_id,
+                parent_ingestion_id,
+            ),
         )
         await db.commit()
         return cur.lastrowid

--- a/database/init.sql
+++ b/database/init.sql
@@ -114,9 +114,13 @@ CREATE TABLE IF NOT EXISTS ingestions (
     admin_id INTEGER,
     action TEXT NOT NULL DEFAULT 'add',
     file_unique_id TEXT,
+    chain_id INTEGER,
+    parent_ingestion_id INTEGER,
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (material_id) REFERENCES materials(id),
-    FOREIGN KEY (admin_id) REFERENCES admins(id)
+    FOREIGN KEY (admin_id) REFERENCES admins(id),
+    FOREIGN KEY (chain_id) REFERENCES ingestions(id),
+    FOREIGN KEY (parent_ingestion_id) REFERENCES ingestions(id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_ingestions_material

--- a/tests/test_follow_chain.py
+++ b/tests/test_follow_chain.py
@@ -1,0 +1,159 @@
+import os
+import pytest
+from types import SimpleNamespace
+import itertools
+import time
+
+os.environ.setdefault("BOT_TOKEN", "x")
+os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
+os.environ.setdefault("OWNER_TG_ID", "1")
+
+from bot.handlers import ingestion
+
+pytestmark = pytest.mark.anyio
+
+
+def setup_environment(monkeypatch):
+    calls = []
+    counter = itertools.count(1)
+
+    async def fake_insert_ingestion(
+        tg_message_id,
+        admin_id,
+        status="pending",
+        action="add",
+        file_unique_id=None,
+        chain_id=None,
+        parent_ingestion_id=None,
+    ):
+        iid = next(counter)
+        calls.append((iid, chain_id, parent_ingestion_id))
+        return iid
+
+    async def fake_parse_hashtags(text):
+        tag = text.lstrip("#")
+        return (
+            SimpleNamespace(
+                year=None,
+                content_type=tag,
+                title="t",
+                lecturer=None,
+                tags=[],
+                lecture_no=None,
+            ),
+            None,
+        )
+
+    async def fake_get_admin_with_permissions(user_id):
+        return (1, ingestion.UPLOAD_CONTENT)
+
+    async def fake_get_group_id_by_chat(chat_id):
+        return (1, 1, 1)
+
+    async def fake_get_binding(chat_id, thread_id):
+        return {"subject_id": 1, "subject_name": "s", "section": "theory"}
+
+    async def fake_send_ephemeral(*args, **kwargs):
+        return None
+
+    async def fake_copy_message(*args, **kwargs):
+        return None
+
+    def fake_get_file_unique_id_from_message(message):
+        return None
+
+    async def fake_attach_material(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(ingestion, "insert_ingestion", fake_insert_ingestion)
+    monkeypatch.setattr(ingestion, "parse_hashtags", fake_parse_hashtags)
+    monkeypatch.setattr(ingestion, "get_admin_with_permissions", fake_get_admin_with_permissions)
+    monkeypatch.setattr(ingestion, "get_group_id_by_chat", fake_get_group_id_by_chat)
+    monkeypatch.setattr(ingestion, "get_binding", fake_get_binding)
+    monkeypatch.setattr(ingestion, "send_ephemeral", fake_send_ephemeral)
+    monkeypatch.setattr(ingestion, "attach_material", fake_attach_material)
+    async def fake_find_exact(*args, **kwargs):
+        return None
+
+    async def fake_insert_material(*args, **kwargs):
+        return 1
+
+    monkeypatch.setattr(ingestion, "find_exact", fake_find_exact)
+    monkeypatch.setattr(ingestion, "insert_material", fake_insert_material)
+    monkeypatch.setattr(ingestion, "get_or_create_year", lambda *a, **k: None)
+    monkeypatch.setattr(ingestion, "get_or_create_lecturer", lambda *a, **k: None)
+    monkeypatch.setattr(ingestion, "get_file_unique_id_from_message", fake_get_file_unique_id_from_message)
+
+    bot = SimpleNamespace(copy_message=fake_copy_message)
+    context = SimpleNamespace(user_data={}, chat_data={}, bot=bot)
+
+    return context, calls
+
+
+def make_update(text, msg_id=1):
+    message = SimpleNamespace(
+        caption=None,
+        text=text,
+        chat_id=111,
+        message_id=msg_id,
+        message_thread_id=1,
+    )
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_chat=SimpleNamespace(id=111),
+        effective_user=SimpleNamespace(id=42),
+    )
+    return update
+
+
+async def test_follow_chain_sequence(monkeypatch):
+    context, calls = setup_environment(monkeypatch)
+    msg_id = itertools.count(1)
+
+    await ingestion.ingestion_handler(make_update("#slides", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("//follow", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("#board_images", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("#audio", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("//end", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("#video", next(msg_id)), context)
+
+    assert calls == [
+        (1, None, None),
+        (2, 1, 1),
+        (3, 1, 2),
+        (4, None, None),
+    ]
+
+
+async def test_cancel_follow_chain(monkeypatch):
+    context, calls = setup_environment(monkeypatch)
+    msg_id = itertools.count(1)
+
+    await ingestion.ingestion_handler(make_update("#slides", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("//follow", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("#board_images", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("//cancel", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("#video", next(msg_id)), context)
+
+    assert calls == [
+        (1, None, None),
+        (2, 1, 1),
+        (3, None, None),
+    ]
+
+
+async def test_chain_timeout(monkeypatch):
+    context, calls = setup_environment(monkeypatch)
+    msg_id = itertools.count(1)
+
+    await ingestion.ingestion_handler(make_update("#slides", next(msg_id)), context)
+    await ingestion.ingestion_handler(make_update("//follow", next(msg_id)), context)
+    # expire chain
+    key = (111, 42)
+    context.chat_data["follow_chains"][key]["expires_at"] = time.time() - 1
+    await ingestion.ingestion_handler(make_update("#board_images", next(msg_id)), context)
+
+    assert calls == [
+        (1, None, None),
+        (2, None, None),
+    ]

--- a/tests/test_single_hashtag_ingestion.py
+++ b/tests/test_single_hashtag_ingestion.py
@@ -54,6 +54,22 @@ async def _prepare(monkeypatch, binding):
     async def fake_copy_message(*args, **kwargs):
         return None
 
+    async def fake_parse_hashtags(text):
+        return (
+            SimpleNamespace(
+                year=None,
+                content_type=None,
+                title="",
+                lecturer=None,
+                tags=["#التوصيف"],
+                lecture_no=None,
+            ),
+            None,
+        )
+
+    async def fake_classify_hashtag(tag):
+        return ("card", "syllabus")
+
     monkeypatch.setattr(ingestion, "insert_material", fake_insert_material)
     monkeypatch.setattr(ingestion, "insert_ingestion", fake_insert_ingestion)
     monkeypatch.setattr(ingestion, "attach_material", fake_attach_material)
@@ -63,6 +79,8 @@ async def _prepare(monkeypatch, binding):
     monkeypatch.setattr(ingestion, "find_exact", fake_find_exact)
     monkeypatch.setattr(ingestion, "send_ephemeral", fake_send_ephemeral)
     monkeypatch.setattr(ingestion, "get_file_unique_id_from_message", fake_get_file_unique_id_from_message)
+    monkeypatch.setattr(ingestion, "parse_hashtags", fake_parse_hashtags)
+    monkeypatch.setattr(ingestion, "classify_hashtag", fake_classify_hashtag)
 
     context = SimpleNamespace(user_data={}, bot=SimpleNamespace(copy_message=fake_copy_message))
 


### PR DESCRIPTION
## Summary
- track follow chains per user and chat to group related ingestions
- persist chain metadata (chain and parent IDs) in DB schema
- add tests covering follow, cancel and timeout flows

## Testing
- `pytest tests/test_follow_chain.py tests/test_single_hashtag_ingestion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c24b7988329b9fc2c6da6f12590