### PR TITLE
Switch taxonomy to ID-based interface

### DIFF
--- a/bot/handlers/ingestion.py
+++ b/bot/handlers/ingestion.py
@@ -20,6 +20,7 @@ from ..db.materials import insert_material, find_exact
 from bot.db.admins import is_owner
 from ..parser.hashtags import parse_hashtags, classify_hashtag
 from ..utils.telegram import send_ephemeral, get_file_unique_id_from_message
+from ..policies.sensitivity import policy as sensitivity_policy
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ async def ingestion_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     message = update.effective_message
     file_unique_id = get_file_unique_id_from_message(message)
     text = message.caption or message.text or ""
-    info, error = parse_hashtags(text)
+    info, error = await parse_hashtags(text)
     if error:
         await send_ephemeral(
             context,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,38 +30,43 @@ def repo_db(tmp_path, monkeypatch):
                 """
                 CREATE TABLE sections (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    key TEXT UNIQUE,
                     label_ar TEXT,
                     label_en TEXT,
                     is_enabled INTEGER,
-                    sort_order INTEGER
+                    sort_order INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE TABLE cards (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    key TEXT UNIQUE,
+                    section_id INTEGER,
                     label_ar TEXT,
                     label_en TEXT,
-                    section_id INTEGER,
                     show_when_empty INTEGER,
                     is_enabled INTEGER,
-                    sort_order INTEGER
+                    sort_order INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE TABLE item_types (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    key TEXT UNIQUE,
                     label_ar TEXT,
                     label_en TEXT,
                     requires_lecture INTEGER,
                     allows_year INTEGER,
                     allows_lecturer INTEGER,
                     is_enabled INTEGER,
-                    sort_order INTEGER
+                    sort_order INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE TABLE subject_section_enable (
                     subject_id INTEGER,
                     section_id INTEGER,
                     is_enabled INTEGER,
                     sort_order INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY(subject_id, section_id)
                 );
                 CREATE TABLE hashtag_aliases (

--- a/tests/test_repo_materials.py
+++ b/tests/test_repo_materials.py
@@ -4,9 +4,9 @@ from bot.repo import materials, taxonomy
 
 
 def test_materials_crud(repo_db):
-    sid = asyncio.run(taxonomy.create_section("theory", "نظري", "Theory"))
-    cid = asyncio.run(taxonomy.create_card("lecture", "محاضرة", "Lecture", section_id=sid))
-    iid = asyncio.run(taxonomy.create_item_type("file", "ملف", "File"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
+    cid = asyncio.run(taxonomy.create_card("محاضرة", "Lecture", section_id=sid))
+    iid = asyncio.run(taxonomy.create_item_type("ملف", "File"))
     mid = asyncio.run(
         materials.insert_material(
             subject_id=1,

--- a/tests/test_repo_taxonomy.py
+++ b/tests/test_repo_taxonomy.py
@@ -4,41 +4,41 @@ from bot.repo import taxonomy
 
 
 def test_section_crud(repo_db):
-    sid = asyncio.run(taxonomy.create_section("theory", "نظري", "Theory"))
-    row = asyncio.run(taxonomy.get_section("theory"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
+    row = asyncio.run(taxonomy.get_section(sid))
     assert row[0] == sid
     asyncio.run(taxonomy.update_section(sid, label_en="Theory Updated"))
-    row = asyncio.run(taxonomy.get_section("theory"))
-    assert row[3] == "Theory Updated"
+    row = asyncio.run(taxonomy.get_section(sid))
+    assert row[2] == "Theory Updated"
     asyncio.run(taxonomy.delete_section(sid))
-    assert asyncio.run(taxonomy.get_section("theory")) is None
+    assert asyncio.run(taxonomy.get_section(sid)) is None
 
 
 def test_card_crud(repo_db):
-    section_id = asyncio.run(taxonomy.create_section("lab", "عملي", "Lab"))
-    cid = asyncio.run(taxonomy.create_card("slides", "سلايدات", "Slides", section_id=section_id))
-    row = asyncio.run(taxonomy.get_card("slides"))
+    section_id = asyncio.run(taxonomy.create_section("عملي", "Lab"))
+    cid = asyncio.run(taxonomy.create_card("سلايدات", "Slides", section_id=section_id))
+    row = asyncio.run(taxonomy.get_card(cid))
     assert row[0] == cid
     asyncio.run(taxonomy.update_card(cid, label_en="Slides Updated"))
-    row = asyncio.run(taxonomy.get_card("slides"))
+    row = asyncio.run(taxonomy.get_card(cid))
     assert row[3] == "Slides Updated"
     asyncio.run(taxonomy.delete_card(cid))
-    assert asyncio.run(taxonomy.get_card("slides")) is None
+    assert asyncio.run(taxonomy.get_card(cid)) is None
 
 
 def test_item_type_crud(repo_db):
-    iid = asyncio.run(taxonomy.create_item_type("pdf", "بي دي اف", "PDF", requires_lecture=True))
-    row = asyncio.run(taxonomy.get_item_type("pdf"))
+    iid = asyncio.run(taxonomy.create_item_type("بي دي اف", "PDF", requires_lecture=True))
+    row = asyncio.run(taxonomy.get_item_type(iid))
     assert row[0] == iid
     asyncio.run(taxonomy.update_item_type(iid, label_en="PDF Updated"))
-    row = asyncio.run(taxonomy.get_item_type("pdf"))
-    assert row[3] == "PDF Updated"
+    row = asyncio.run(taxonomy.get_item_type(iid))
+    assert row[2] == "PDF Updated"
     asyncio.run(taxonomy.delete_item_type(iid))
-    assert asyncio.run(taxonomy.get_item_type("pdf")) is None
+    assert asyncio.run(taxonomy.get_item_type(iid)) is None
 
 
 def test_subject_section_enable(repo_db):
-    sid = asyncio.run(taxonomy.create_section("disc", "نقاش", "Discussion"))
+    sid = asyncio.run(taxonomy.create_section("نقاش", "Discussion"))
     asyncio.run(taxonomy.set_subject_section_enable(1, sid, sort_order=2))
     rows = asyncio.run(taxonomy.get_enabled_sections_for_subject(1))
     assert rows == [(sid, 1, 2)]


### PR DESCRIPTION
## Summary
- migrate taxonomy repository to id-based lookups and include timestamps
- export/import taxonomy tables using ids instead of keys
- adjust ingestion handler to await hashtag parsing and expose sensitivity policy
- update tests and fixtures for new schema

## Testing
- `pytest tests/test_repo_taxonomy.py tests/test_repo_materials.py tests/test_import_export.py -q`
- `pytest -q` *(fails: TypeError: object tuple can't be used in 'await' expression, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bf32eacc0c83299efe02fd7542efb8