### PR TITLE
refactor repo connections and error handling

### DIFF
--- a/bot/repo/__init__.py
+++ b/bot/repo/__init__.py
@@ -1,10 +1,77 @@
 """Database repository layer.
 
-This package contains thin wrappers around the raw SQL queries used
-in the bot.  Handlers interact with the database exclusively through
-these functions which keeps the higher level logic independent from
-the underlying storage implementation.
+This package contains thin wrappers around the raw SQL queries used in the
+bot. Handlers interact with the database exclusively through these functions
+which keeps the higher level logic independent from the underlying storage
+implementation.
+
+It also exposes a :func:`connect` helper and a small set of exceptions that
+provide a unified error handling surface for all repository modules.
 """
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import asynccontextmanager
+from functools import wraps
+from typing import Any, AsyncIterator, Awaitable, Callable, ParamSpec, TypeVar
+
+import aiosqlite
+
+from bot.db import base
+
+
+class RepoError(Exception):
+    """Base error for repository operations."""
+
+
+class RepoNotFound(RepoError):
+    """Raised when a requested record is missing."""
+
+
+class RepoConflict(RepoError):
+    """Raised when an operation encounters a conflict."""
+
+
+class RepoConstraintError(RepoError):
+    """Raised when database constraints are violated."""
+
+
+@asynccontextmanager
+async def connect() -> AsyncIterator[aiosqlite.Connection]:
+    """Create a new DB connection with foreign keys enabled.
+
+    ينشئ اتصالاً جديداً بقاعدة البيانات مع تفعيل قيود العلاقات.
+    """
+
+    async with aiosqlite.connect(base.DB_PATH) as db:
+        await db.execute("PRAGMA foreign_keys=ON")
+        yield db
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def translate_errors(
+    func: Callable[P, Awaitable[T]]
+) -> Callable[P, Awaitable[T]]:
+    """Translate low-level DB errors to repository exceptions.
+
+    غلاف لترجمة أخطاء قاعدة البيانات إلى استثناءات المخرن.
+    """
+
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        try:
+            return await func(*args, **kwargs)
+        except sqlite3.IntegrityError as exc:  # pragma: no cover - exercised via wrapper
+            raise RepoConstraintError(str(exc)) from exc
+        except aiosqlite.Error as exc:  # pragma: no cover
+            raise RepoError(str(exc)) from exc
+
+    return wrapper
+
 
 __all__ = [
     "taxonomy",
@@ -12,4 +79,11 @@ __all__ = [
     "materials",
     "linking",
     "rbac",
+    "connect",
+    "translate_errors",
+    "RepoError",
+    "RepoNotFound",
+    "RepoConflict",
+    "RepoConstraintError",
 ]
+

--- a/bot/repo/hashtags.py
+++ b/bot/repo/hashtags.py
@@ -1,16 +1,29 @@
 """Repository helpers for hashtag aliasing and mappings."""
 from __future__ import annotations
 
-import aiosqlite
-
-from bot.db import base
+from . import connect, translate_errors
 
 # ---------------------------------------------------------------------------
 # Aliases
 # ---------------------------------------------------------------------------
+@translate_errors
 async def create_alias(alias: str, normalized: str, *, lang: str | None = None) -> int:
-    """Insert a new alias and return its id."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """إضافة اسم بديل وإرجاع معرفه | Insert alias and return its id.
+
+    Args:
+        alias: الاسم الأصلي / original alias.
+        normalized: الاسم المعياري / normalized form.
+        lang: رمز اللغة أو ``None``.
+
+    Returns:
+        int: المعرف الجديد / new row id.
+
+    Raises:
+        RepoConstraintError: عند تعارض القيود / on constraint conflict.
+        RepoError: أخطاء قاعدة البيانات الأخرى / other DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             "INSERT INTO hashtag_aliases (alias, normalized, lang) VALUES (?, ?, ?)",
             (alias, normalized, lang),
@@ -19,9 +32,21 @@ async def create_alias(alias: str, normalized: str, *, lang: str | None = None) 
         return cur.lastrowid
 
 
+@translate_errors
 async def get_alias(alias: str) -> tuple | None:
-    """Return alias row for *alias* or ``None`` if missing."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """الحصول على صف الاسم أو ``None`` | Return alias row or ``None``.
+
+    Args:
+        alias: النص المطلوب / alias string.
+
+    Returns:
+        tuple | None: صف قاعدة البيانات أو ``None`` / DB row or ``None``.
+
+    Raises:
+        RepoError: عند فشل الاتصال أو الاستعلام / on DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             "SELECT id, alias, normalized, lang FROM hashtag_aliases WHERE alias=?",
             (alias,),
@@ -29,31 +54,72 @@ async def get_alias(alias: str) -> tuple | None:
         return await cur.fetchone()
 
 
+@translate_errors
 async def update_alias(alias_id: int, **fields) -> None:
-    """Update an alias row with supplied *fields*."""
+    """تحديث صف اسم بديل | Update alias row.
+
+    Args:
+        alias_id: معرف الصف / row id.
+        **fields: الحقول المعدلة / fields to update.
+
+    Raises:
+        RepoError: أخطاء قاعدة البيانات / DB errors.
+    """
+
     if not fields:
         return
     cols = ", ".join(f"{k}=?" for k in fields)
     params = list(fields.values()) + [alias_id]
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    async with connect() as db:
         await db.execute(f"UPDATE hashtag_aliases SET {cols} WHERE id=?", params)
         await db.commit()
 
 
+@translate_errors
 async def delete_alias(alias_id: int) -> None:
-    """Delete alias with id *alias_id*."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """حذف الاسم بالمعرف | Delete alias by id.
+
+    Args:
+        alias_id: معرف الصف / row id.
+
+    Raises:
+        RepoError: عند حدوث خطأ في قاعدة البيانات / DB error.
+    """
+
+    async with connect() as db:
         await db.execute("DELETE FROM hashtag_aliases WHERE id=?", (alias_id,))
         await db.commit()
 
 # ---------------------------------------------------------------------------
 # Mappings
 # ---------------------------------------------------------------------------
-async def create_mapping(alias_id: int, target_kind: str, target_id: int, *,
-                         is_content_tag: bool = False,
-                         overrides: str | None = None) -> int:
-    """Insert a mapping from an alias to a target entity."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+@translate_errors
+async def create_mapping(
+    alias_id: int,
+    target_kind: str,
+    target_id: int,
+    *,
+    is_content_tag: bool = False,
+    overrides: str | None = None,
+) -> int:
+    """ربط اسم بكيان آخر | Map alias to target.
+
+    Args:
+        alias_id: معرف الاسم / alias id.
+        target_kind: نوع الهدف / target kind.
+        target_id: معرف الهدف / target id.
+        is_content_tag: هل هو وسم محتوى؟ / content tag flag.
+        overrides: بيانات إضافية / override data.
+
+    Returns:
+        int: معرف الربط / mapping id.
+
+    Raises:
+        RepoConstraintError: عند فشل القيود / on constraint conflict.
+        RepoError: أخطاء قاعدة البيانات الأخرى / other DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             """INSERT INTO hashtag_mappings
                 (alias_id, target_kind, target_id, is_content_tag, overrides)
@@ -64,9 +130,21 @@ async def create_mapping(alias_id: int, target_kind: str, target_id: int, *,
         return cur.lastrowid
 
 
+@translate_errors
 async def get_mappings_for_alias(alias: str) -> list[tuple]:
-    """Return mapping rows for *alias* string."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """إرجاع كل الربوط للاسم | Return mapping rows for alias.
+
+    Args:
+        alias: النص المطلوب / alias string.
+
+    Returns:
+        list[tuple]: قائمة الربوط / list of mappings.
+
+    Raises:
+        RepoError: أخطاء قاعدة البيانات / DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             """SELECT m.id, a.alias, m.target_kind, m.target_id, m.is_content_tag, m.overrides
                 FROM hashtag_mappings m
@@ -77,10 +155,19 @@ async def get_mappings_for_alias(alias: str) -> list[tuple]:
         return await cur.fetchall()
 
 
+@translate_errors
 async def lookup_targets(alias: str) -> list[tuple[str, int]]:
-    """Return ``(target_kind, target_id)`` pairs for *alias*.
+    """الحصول على أهداف الاسم | Return ``(target_kind, target_id)`` pairs.
 
-    The lookup first resolves the alias then returns all mapped targets.
+    Args:
+        alias: الاسم المراد البحث عنه / alias to resolve.
+
+    Returns:
+        list[tuple[str, int]]: أزواج الهدف / target pairs.
+
+    Raises:
+        RepoError: عند فشل العمليات / DB errors.
     """
+
     rows = await get_mappings_for_alias(alias)
     return [(r[2], r[3]) for r in rows]

--- a/bot/repo/linking.py
+++ b/bot/repo/linking.py
@@ -1,16 +1,36 @@
 """Repository helpers for linking Telegram entities to subjects and sections."""
 from __future__ import annotations
 
-import aiosqlite
+from . import RepoNotFound, connect, translate_errors
 
-from bot.db import base
+@translate_errors
+async def upsert_group(
+    tg_chat_id: int,
+    title: str,
+    *,
+    level_id: int | None = None,
+    term_id: int | None = None,
+    section_id: int | None = None,
+) -> int:
+    """إضافة/تحديث مجموعة | Insert or update a group.
 
-async def upsert_group(tg_chat_id: int, title: str,
-                       *, level_id: int | None = None,
-                       term_id: int | None = None,
-                       section_id: int | None = None) -> int:
-    """Insert or update a group record and return its id."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    Args:
+        tg_chat_id: معرف الدردشة / chat identifier.
+        title: عنوان المجموعة / group title.
+        level_id: معرف المستوى أو ``None``.
+        term_id: معرف الفصل أو ``None``.
+        section_id: معرف الشعبة أو ``None``.
+
+    Returns:
+        int: معرف المجموعة / group id.
+
+    Raises:
+        RepoConstraintError: عند فشل القيود / on constraint issues.
+        RepoNotFound: إذا تعذر إيجاد السجل بعد التحديث / if record missing.
+        RepoError: أخطاء قاعدة البيانات / other DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             """INSERT INTO groups (tg_chat_id, title, level_id, term_id, section_id)
                 VALUES (?, ?, ?, ?, ?)
@@ -24,16 +44,31 @@ async def upsert_group(tg_chat_id: int, title: str,
         await db.commit()
         if cur.lastrowid:
             return cur.lastrowid
-        # On conflict SQLite returns 0; fetch existing id
-        cur = await db.execute("SELECT id FROM groups WHERE tg_chat_id=?", (tg_chat_id,))
+        cur = await db.execute(
+            "SELECT id FROM groups WHERE tg_chat_id=?",
+            (tg_chat_id,),
+        )
         row = await cur.fetchone()
-        assert row is not None
+        if row is None:
+            raise RepoNotFound(f"group {tg_chat_id!r} not found")
         return row[0]
 
 
+@translate_errors
 async def get_group(tg_chat_id: int) -> tuple | None:
-    """Return group row for *tg_chat_id* or ``None``."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """إرجاع صف المجموعة أو ``None`` | Return group row or ``None``.
+
+    Args:
+        tg_chat_id: معرف الدردشة / chat identifier.
+
+    Returns:
+        tuple | None: صف المجموعة / group row.
+
+    Raises:
+        RepoError: خطأ قاعدة البيانات / DB error.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             "SELECT id, tg_chat_id, title, level_id, term_id, section_id FROM groups WHERE tg_chat_id=?",
             (tg_chat_id,),
@@ -41,10 +76,32 @@ async def get_group(tg_chat_id: int) -> tuple | None:
         return await cur.fetchone()
 
 
-async def upsert_topic(group_id: int, tg_topic_id: int, subject_id: int,
-                       *, section_id: int | None = None) -> int:
-    """Insert or update a topic linking to a subject/section."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+@translate_errors
+async def upsert_topic(
+    group_id: int,
+    tg_topic_id: int,
+    subject_id: int,
+    *,
+    section_id: int | None = None,
+) -> int:
+    """إضافة/تحديث موضوع | Insert or update a topic mapping.
+
+    Args:
+        group_id: معرف المجموعة / group id.
+        tg_topic_id: معرف موضوع تيليغرام / Telegram topic id.
+        subject_id: معرف المادة / subject id.
+        section_id: معرف الشعبة أو ``None``.
+
+    Returns:
+        int: معرف الموضوع / topic id.
+
+    Raises:
+        RepoConstraintError: عند فشل القيود.
+        RepoNotFound: إذا لم يوجد السجل.
+        RepoError: أخطاء قاعدة البيانات الأخرى.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             """INSERT INTO topics (group_id, tg_topic_id, subject_id, section_id)
                 VALUES (?, ?, ?, ?)
@@ -61,13 +118,27 @@ async def upsert_topic(group_id: int, tg_topic_id: int, subject_id: int,
             (group_id, tg_topic_id),
         )
         row = await cur.fetchone()
-        assert row is not None
+        if row is None:
+            raise RepoNotFound("topic not found")
         return row[0]
 
 
+@translate_errors
 async def get_topic(group_id: int, tg_topic_id: int) -> tuple | None:
-    """Return topic row for identifiers."""
-    async with aiosqlite.connect(base.DB_PATH) as db:
+    """إرجاع صف الموضوع أو ``None`` | Return topic row or ``None``.
+
+    Args:
+        group_id: معرف المجموعة / group id.
+        tg_topic_id: معرف موضوع تيليغرام / Telegram topic id.
+
+    Returns:
+        tuple | None: صف الموضوع / topic row.
+
+    Raises:
+        RepoError: أخطاء قاعدة البيانات / DB errors.
+    """
+
+    async with connect() as db:
         cur = await db.execute(
             "SELECT id, group_id, tg_topic_id, subject_id, section_id FROM topics WHERE group_id=? AND tg_topic_id=?",
             (group_id, tg_topic_id),


### PR DESCRIPTION
## Summary
- centralize aiosqlite connections with `connect()` enabling foreign keys
- add repository exception hierarchy and error translation decorator
- refactor repository modules to use shared connection, error handling, and bilingual docstrings

## Testing
- `pytest -q` (fails: TypeError in ingestion handler and follow chain tests)
- `pytest tests/test_repo_hashtags.py tests/test_repo_linking.py tests/test_repo_materials.py tests/test_repo_rbac.py tests/test_repo_taxonomy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf41cf9a44832986d9538c06d5e34d