### PR TITLE
Add CRUD and localization helpers for taxonomy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,16 @@ def repo_db(tmp_path, monkeypatch):
                     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                     updated_at TEXT DEFAULT CURRENT_TIMESTAMP
                 );
+                CREATE TABLE section_item_types (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    section_id INTEGER NOT NULL,
+                    item_type_id INTEGER NOT NULL,
+                    is_enabled INTEGER,
+                    sort_order INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(section_id, item_type_id)
+                );
                 CREATE TABLE subject_section_enable (
                     subject_id INTEGER,
                     section_id INTEGER,

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -6,13 +6,13 @@ from bot.repo import taxonomy, hashtags
 
 
 def test_export_import_roundtrip(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))["id"]
     cid = asyncio.run(
         taxonomy.create_card("سلايدات", "Slides", section_id=sid, show_when_empty=1)
-    )
+    )["id"]
     iid = asyncio.run(
         taxonomy.create_item_type("بي دي اف", "PDF", requires_lecture=1)
-    )
+    )["id"]
     alias_id = asyncio.run(hashtags.create_alias("hw", "hw"))
     asyncio.run(hashtags.create_mapping(alias_id, "card", cid))
     asyncio.run(taxonomy.set_subject_section_enable(1, sid, sort_order=1))
@@ -28,7 +28,7 @@ def test_export_import_roundtrip(repo_db):
 
 
 def test_dry_run_and_upsert(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))["id"]
     data = {
         "sections": [
             {"id": sid, "label_ar": "نظري", "label_en": "Theory 2", "is_enabled": 1, "sort_order": 0}
@@ -40,12 +40,12 @@ def test_dry_run_and_upsert(repo_db):
     assert report["conflicts"]["sections"] == [sid]
     report = asyncio.run(import_export.import_taxonomy(data))
     assert report["update"]["sections"] == [sid]
-    row = asyncio.run(taxonomy.get_section(sid))
-    assert row[2] == "Theory 2"
+    row = asyncio.run(taxonomy.get_section(sid, lang="en", include_disabled=True))
+    assert row["label"] == "Theory 2"
 
 
 def test_strict_mode_raises(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))["id"]
     data = {
         "sections": [
             {"id": sid, "label_ar": "نظري", "label_en": "Changed", "is_enabled": 1, "sort_order": 0}

--- a/tests/test_repo_materials.py
+++ b/tests/test_repo_materials.py
@@ -4,9 +4,9 @@ from bot.repo import materials, taxonomy
 
 
 def test_materials_crud(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
-    cid = asyncio.run(taxonomy.create_card("محاضرة", "Lecture", section_id=sid))
-    iid = asyncio.run(taxonomy.create_item_type("ملف", "File"))
+    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))["id"]
+    cid = asyncio.run(taxonomy.create_card("محاضرة", "Lecture", section_id=sid))["id"]
+    iid = asyncio.run(taxonomy.create_item_type("ملف", "File"))["id"]
     mid = asyncio.run(
         materials.insert_material(
             subject_id=1,

--- a/tests/test_repo_taxonomy.py
+++ b/tests/test_repo_taxonomy.py
@@ -3,42 +3,106 @@ import asyncio
 from bot.repo import taxonomy
 
 
-def test_section_crud(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))
-    row = asyncio.run(taxonomy.get_section(sid))
-    assert row[0] == sid
-    asyncio.run(taxonomy.update_section(sid, label_en="Theory Updated"))
-    row = asyncio.run(taxonomy.get_section(sid))
-    assert row[2] == "Theory Updated"
-    asyncio.run(taxonomy.delete_section(sid))
-    assert asyncio.run(taxonomy.get_section(sid)) is None
+def _run(coro):
+    return asyncio.run(coro)
 
 
-def test_card_crud(repo_db):
-    section_id = asyncio.run(taxonomy.create_section("عملي", "Lab"))
-    cid = asyncio.run(taxonomy.create_card("سلايدات", "Slides", section_id=section_id))
-    row = asyncio.run(taxonomy.get_card(cid))
-    assert row[0] == cid and row[1] == section_id
-    asyncio.run(taxonomy.update_card(cid, label_en="Slides Updated"))
-    row = asyncio.run(taxonomy.get_card(cid))
-    assert row[3] == "Slides Updated"
-    asyncio.run(taxonomy.delete_card(cid))
-    assert asyncio.run(taxonomy.get_card(cid)) is None
+def test_crud_and_language(repo_db):
+    # Sections
+    sec1 = _run(taxonomy.create_section("نظري", "Theory", sort_order=2))
+    sec2 = _run(
+        taxonomy.create_section("عملي", "Lab", sort_order=1, is_enabled=False)
+    )
+
+    assert _run(taxonomy.get_section(sec1["id"], lang="en"))["label"] == "Theory"
+    _run(taxonomy.update_section(sec1["id"], label_en="Theory Updated"))
+    assert (
+        _run(taxonomy.get_section(sec1["id"], lang="en"))["label"]
+        == "Theory Updated"
+    )
+    assert _run(taxonomy.get_section(sec2["id"])) is None
+
+    sections = _run(taxonomy.get_sections())
+    assert [s["id"] for s in sections] == [sec1["id"]]
+    sections_all = _run(taxonomy.get_sections(lang="en", include_disabled=True))
+    assert [s["id"] for s in sections_all] == [sec2["id"], sec1["id"]]
+    assert sections_all[0]["label"] == "Lab"
+
+    # Cards
+    card1 = _run(
+        taxonomy.create_card("سلايدات", "Slides", section_id=sec1["id"], sort_order=1)
+    )
+    card2 = _run(
+        taxonomy.create_card(
+            "مراجع", "References", section_id=sec1["id"], sort_order=0, is_enabled=False
+        )
+    )
+    assert _run(taxonomy.get_card(card1["id"], lang="en"))["label"] == "Slides"
+    _run(taxonomy.update_card(card1["id"], label_en="Slides Updated"))
+    assert (
+        _run(taxonomy.get_card(card1["id"], lang="en"))["label"]
+        == "Slides Updated"
+    )
+    cards = _run(taxonomy.get_cards(section_id=sec1["id"]))
+    assert [c["id"] for c in cards] == [card1["id"]]
+    cards_all = _run(
+        taxonomy.get_cards(section_id=sec1["id"], include_disabled=True, lang="en")
+    )
+    assert [c["id"] for c in cards_all] == [card2["id"], card1["id"]]
+    assert cards_all[0]["label"] == "References"
+    _run(taxonomy.delete_card(card1["id"]))
+    assert _run(taxonomy.get_card(card1["id"])) is None
+
+    # Item types
+    it1 = _run(taxonomy.create_item_type("بي دي اف", "PDF", sort_order=1))
+    it2 = _run(
+        taxonomy.create_item_type("صورة", "Image", sort_order=0, is_enabled=False)
+    )
+    assert _run(taxonomy.get_item_type(it1["id"], lang="en"))["label"] == "PDF"
+    _run(taxonomy.update_item_type(it1["id"], label_en="PDF Updated"))
+    assert (
+        _run(taxonomy.get_item_type(it1["id"], lang="en"))["label"]
+        == "PDF Updated"
+    )
+    item_types = _run(taxonomy.get_item_types())
+    assert [i["id"] for i in item_types] == [it1["id"]]
+    item_types_all = _run(taxonomy.get_item_types(include_disabled=True, lang="en"))
+    assert [i["id"] for i in item_types_all] == [it2["id"], it1["id"]]
+    assert item_types_all[0]["label"] == "Image"
+    _run(taxonomy.delete_item_type(it1["id"]))
+    assert _run(taxonomy.get_item_type(it1["id"])) is None
 
 
-def test_item_type_crud(repo_db):
-    iid = asyncio.run(taxonomy.create_item_type("بي دي اف", "PDF", requires_lecture=True))
-    row = asyncio.run(taxonomy.get_item_type(iid))
-    assert row[0] == iid
-    asyncio.run(taxonomy.update_item_type(iid, label_en="PDF Updated"))
-    row = asyncio.run(taxonomy.get_item_type(iid))
-    assert row[2] == "PDF Updated"
-    asyncio.run(taxonomy.delete_item_type(iid))
-    assert asyncio.run(taxonomy.get_item_type(iid)) is None
+def test_section_item_types_and_subject_sections(repo_db):
+    sec = _run(taxonomy.create_section("نظري", "Theory"))
+    it1 = _run(taxonomy.create_item_type("بي دي اف", "PDF", sort_order=1))
+    it2 = _run(taxonomy.create_item_type("صورة", "Image", sort_order=0))
 
+    _run(taxonomy.set_section_item_type(sec["id"], it1["id"], sort_order=1))
+    _run(
+        taxonomy.set_section_item_type(
+            sec["id"], it2["id"], sort_order=0, is_enabled=False
+        )
+    )
+    items = _run(taxonomy.get_item_types_for_section(sec["id"]))
+    assert [i["id"] for i in items] == [it1["id"]]
+    items_all = _run(
+        taxonomy.get_item_types_for_section(sec["id"], include_disabled=True, lang="en")
+    )
+    assert [i["id"] for i in items_all] == [it2["id"], it1["id"]]
+    assert items_all[0]["label"] == "Image"
 
-def test_subject_section_enable(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نقاش", "Discussion"))
-    asyncio.run(taxonomy.set_subject_section_enable(1, sid, sort_order=2))
-    rows = asyncio.run(taxonomy.get_enabled_sections_for_subject(1))
-    assert rows == [(sid, 1, 2)]
+    sec2 = _run(taxonomy.create_section("مختبر", "Lab", sort_order=1))
+    _run(taxonomy.set_subject_section_enable(1, sec["id"], sort_order=2))
+    _run(
+        taxonomy.set_subject_section_enable(
+            1, sec2["id"], sort_order=1, is_enabled=False
+        )
+    )
+    enabled = _run(taxonomy.get_sections_for_subject(1))
+    assert [s["id"] for s in enabled] == [sec["id"]]
+    enabled_all = _run(
+        taxonomy.get_sections_for_subject(1, include_disabled=True, lang="en")
+    )
+    assert [s["id"] for s in enabled_all] == [sec2["id"], sec["id"]]
+    assert enabled_all[0]["label"] == "Lab"


### PR DESCRIPTION
## Summary
- expand taxonomy repo with dictionary-based CRUD for sections, cards, and item types
- support localized lookups and filtering by enabled state
- manage section-item type links and subject-section enablement
- add unit tests covering CRUD, linking, ordering, and localization

## Testing
- `pytest tests/test_repo_taxonomy.py tests/test_repo_materials.py tests/test_import_export.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf43d41b5c832990735df5cb190ea0