### PR TITLE
Add alias normalization and lookup helpers

### DIFF
--- a/bot/db/ingestions.py
+++ b/bot/db/ingestions.py
@@ -9,6 +9,9 @@ async def insert_ingestion(
     status: str = "pending",
     action: str = "add",
     file_unique_id: str | None = None,
+    *,
+    chain_id: int | None = None,
+    parent_ingestion_id: int | None = None,
 ) -> int:
     async with aiosqlite.connect(DB_PATH) as db:
         cur = await db.execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,8 @@ def repo_db(tmp_path, monkeypatch):
                     normalized TEXT,
                     lang TEXT
                 );
+                CREATE UNIQUE INDEX ux_hashtag_aliases_normalized
+                    ON hashtag_aliases(normalized COLLATE NOCASE);
                 CREATE TABLE hashtag_mappings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     alias_id INTEGER,
@@ -93,6 +95,8 @@ def repo_db(tmp_path, monkeypatch):
                     is_content_tag INTEGER,
                     overrides TEXT
                 );
+                CREATE UNIQUE INDEX ux_hashtag_mappings_alias
+                    ON hashtag_mappings(alias_id);
                 CREATE TABLE materials (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     subject_id INTEGER NOT NULL,

--- a/tests/test_exam_ingestion.py
+++ b/tests/test_exam_ingestion.py
@@ -28,7 +28,15 @@ async def test_exam_ingestion(tag, expected_category, monkeypatch):
         insert_calls.append((subject_id, section, category, title, kwargs))
         return 10
 
-    async def fake_insert_ingestion(msg_id, admin_id, action="add", file_unique_id=None):
+    async def fake_insert_ingestion(
+        msg_id,
+        admin_id,
+        status="pending",
+        action="add",
+        file_unique_id=None,
+        chain_id=None,
+        parent_ingestion_id=None,
+    ):
         return 99
 
     async def fake_attach_material(ingestion_id, material_id, status):

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -13,7 +13,7 @@ def test_export_import_roundtrip(repo_db):
     iid = asyncio.run(
         taxonomy.create_item_type("بي دي اف", "PDF", requires_lecture=1)
     )["id"]
-    alias_id = asyncio.run(hashtags.create_alias("hw", "hw"))
+    alias_id = asyncio.run(hashtags.create_alias("hw"))
     asyncio.run(hashtags.create_mapping(alias_id, "card", cid))
     asyncio.run(taxonomy.set_subject_section_enable(1, sid, sort_order=1))
 

--- a/tests/test_repo_hashtags.py
+++ b/tests/test_repo_hashtags.py
@@ -1,10 +1,12 @@
 import asyncio
+import pytest
 
 from bot.repo import hashtags
+from bot.repo import RepoConflict
 
 
 def test_alias_crud(repo_db):
-    aid = asyncio.run(hashtags.create_alias("math", "math"))
+    aid = asyncio.run(hashtags.create_alias("math"))
     row = asyncio.run(hashtags.get_alias("math"))
     assert row[0] == aid
     asyncio.run(hashtags.update_alias(aid, normalized="maths"))
@@ -14,10 +16,30 @@ def test_alias_crud(repo_db):
     assert asyncio.run(hashtags.get_alias("math")) is None
 
 
-def test_mapping_and_lookup(repo_db):
-    aid = asyncio.run(hashtags.create_alias("physics", "physics"))
-    mid = asyncio.run(hashtags.create_mapping(aid, "subject", 5))
-    rows = asyncio.run(hashtags.get_mappings_for_alias("physics"))
+def test_normalization_unique_and_lookup(repo_db):
+    aid = asyncio.run(hashtags.create_alias(" PHYsics١ "))
+    row = asyncio.run(hashtags.get_alias(" PHYsics١ "))
+    assert row[2] == "physics1"
+
+    assert asyncio.run(hashtags.is_known_alias("physics1"))
+    assert asyncio.run(hashtags.get_alias_id("physics١")) == aid
+
+    mid = asyncio.run(hashtags.create_mapping(aid, "subject", 5, is_content_tag=True))
+    rows = asyncio.run(hashtags.get_mappings_for_alias("physics1"))
     assert rows[0][0] == mid
-    targets = asyncio.run(hashtags.lookup_targets("physics"))
+    targets = asyncio.run(hashtags.lookup_targets("  physics١  "))
     assert targets == [("subject", 5)]
+    resolved = asyncio.run(hashtags.resolve_content_tag("physics1"))
+    assert resolved == {
+        "target_kind": "subject",
+        "target_id": 5,
+        "is_content_tag": True,
+        "overrides": None,
+    }
+
+    with pytest.raises(RepoConflict):
+        asyncio.run(hashtags.create_alias("physics 1"))
+
+    aid2 = asyncio.run(hashtags.create_alias("chem"))
+    with pytest.raises(RepoConflict):
+        asyncio.run(hashtags.create_mapping(aid2, "subject", 5))

--- a/tests/test_single_hashtag_ingestion.py
+++ b/tests/test_single_hashtag_ingestion.py
@@ -26,7 +26,15 @@ async def _prepare(monkeypatch, binding):
         insert_calls.append((subject_id, section, category, title))
         return 10
 
-    async def fake_insert_ingestion(msg_id, admin_id, action="add", file_unique_id=None):
+    async def fake_insert_ingestion(
+        msg_id,
+        admin_id,
+        status="pending",
+        action="add",
+        file_unique_id=None,
+        chain_id=None,
+        parent_ingestion_id=None,
+    ):
         return 99
 
     async def fake_attach_material(ingestion_id, material_id, status):


### PR DESCRIPTION
## Summary
- Normalize hashtag aliases (lowercase, strip spaces, convert Arabic digits) and surface new lookup helpers
- Enforce unique alias and target constraints, raising RepoConflict on duplicates
- Extend ingestion handler with flexible hashtag parsing, follow-chain commands, and sensitivity checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf4781731c83299d3e58fafe72310f