### PR TITLE
feat: expand materials repository

### DIFF
--- a/bot/repo/materials.py
+++ b/bot/repo/materials.py
@@ -8,7 +8,37 @@ and for handlers that merely need basic persistence.
 """
 from __future__ import annotations
 
-from . import connect, translate_errors
+from . import connect, translate_errors, RepoConstraintError
+
+# Column order helper used to map rows to dictionaries
+_MATERIAL_FIELDS = [
+    "id",
+    "subject_id",
+    "section_id",
+    "category_id",
+    "item_type_id",
+    "title",
+    "url",
+    "year_id",
+    "lecturer_id",
+    "lecture_no",
+    "content_hash",
+    "tg_storage_chat_id",
+    "tg_storage_msg_id",
+    "file_unique_id",
+    "source_chat_id",
+    "source_topic_id",
+    "source_message_id",
+    "created_by_admin_id",
+]
+
+
+def _row_to_dict(row: tuple | None) -> dict | None:
+    """Convert a material row tuple to a dictionary."""
+
+    if row is None:
+        return None
+    return dict(zip(_MATERIAL_FIELDS, row))
 
 @translate_errors
 async def insert_material(
@@ -60,6 +90,10 @@ async def insert_material(
         RepoError: أخطاء قاعدة البيانات.
     """
 
+    # Ensure that exactly one of category_id or item_type_id is provided
+    if (category_id is None) == (item_type_id is None):
+        raise RepoConstraintError("either category_id or item_type_id must be set")
+
     async with connect() as db:
         cur = await db.execute(
             """INSERT INTO materials (
@@ -94,14 +128,14 @@ async def insert_material(
 
 
 @translate_errors
-async def get_material(material_id: int) -> tuple | None:
-    """جلب صف المادة أو ``None`` | Return material row or ``None``.
+async def get_material(material_id: int) -> dict | None:
+    """جلب صف المادة أو ``None`` | Return material as dict or ``None``.
 
     Args:
         material_id: معرف المادة / material id.
 
     Returns:
-        tuple | None: صف المادة / material row.
+        dict | None: صف المادة / material row.
 
     Raises:
         RepoError: عند حدوث خطأ في قاعدة البيانات.
@@ -109,10 +143,28 @@ async def get_material(material_id: int) -> tuple | None:
 
     async with connect() as db:
         cur = await db.execute(
-            "SELECT * FROM materials WHERE id=?",
+            f"SELECT {', '.join(_MATERIAL_FIELDS)} FROM materials WHERE id=?",
             (material_id,),
         )
-        return await cur.fetchone()
+        row = await cur.fetchone()
+
+    return _row_to_dict(row)
+
+
+@translate_errors
+async def update_material(material_id: int, **fields) -> dict | None:
+    """Update fields of a material and return the updated row."""
+
+    if not fields:
+        return await get_material(material_id)
+
+    cols = ", ".join(f"{k}=?" for k in fields)
+    params = list(fields.values()) + [material_id]
+    async with connect() as db:
+        await db.execute(f"UPDATE materials SET {cols} WHERE id=?", params)
+        await db.commit()
+
+    return await get_material(material_id)
 
 
 @translate_errors
@@ -122,60 +174,147 @@ async def update_material_storage(
     msg_id: int,
     *,
     file_unique_id: str | None = None,
-) -> None:
-    """تحديث معلومات التخزين للمادة | Update storage identifiers.
+) -> dict | None:
+    """تحديث معلومات التخزين للمادة | Update storage identifiers."""
 
-    Args:
-        material_id: معرف المادة / material id.
-        chat_id: معرف الدردشة / chat id.
-        msg_id: معرف الرسالة / message id.
-        file_unique_id: معرف الملف أو ``None``.
-
-    Raises:
-        RepoError: أخطاء قاعدة البيانات / DB errors.
-    """
-
-    async with connect() as db:
-        await db.execute(
-            "UPDATE materials SET tg_storage_chat_id=?, tg_storage_msg_id=?, file_unique_id=? WHERE id=?",
-            (chat_id, msg_id, file_unique_id, material_id),
-        )
-        await db.commit()
+    return await update_material(
+        material_id,
+        tg_storage_chat_id=chat_id,
+        tg_storage_msg_id=msg_id,
+        file_unique_id=file_unique_id,
+    )
 
 
 @translate_errors
-async def delete_material(material_id: int) -> None:
-    """حذف سجل مادة | Delete a material record.
+async def delete_material(material_id: int) -> dict | None:
+    """حذف سجل مادة | Delete a material record and return it."""
 
-    Args:
-        material_id: معرف المادة / material id.
-
-    Raises:
-        RepoError: عند فشل قاعدة البيانات.
-    """
+    row = await get_material(material_id)
+    if row is None:
+        return None
 
     async with connect() as db:
         await db.execute("DELETE FROM materials WHERE id=?", (material_id,))
         await db.commit()
 
+    return row
+
 
 @translate_errors
-async def find_by_hash(content_hash: str) -> tuple | None:
-    """البحث عن مادة ببصمة المحتوى | Find material by content hash.
-
-    Args:
-        content_hash: البصمة المراد البحث عنها / hash to search.
-
-    Returns:
-        tuple | None: صف المادة أو ``None`` / material row or ``None``.
-
-    Raises:
-        RepoError: أخطاء قاعدة البيانات / DB errors.
-    """
+async def find_by_hash(content_hash: str) -> dict | None:
+    """البحث عن مادة ببصمة المحتوى | Find material by content hash."""
 
     async with connect() as db:
         cur = await db.execute(
-            "SELECT * FROM materials WHERE content_hash=?",
+            f"SELECT {', '.join(_MATERIAL_FIELDS)} FROM materials WHERE content_hash=?",
             (content_hash,),
         )
-        return await cur.fetchone()
+        row = await cur.fetchone()
+
+    return _row_to_dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Enumeration and listing helpers
+# ---------------------------------------------------------------------------
+
+
+@translate_errors
+async def count_by_subject(subject_id: int) -> int:
+    """Return number of materials for a subject."""
+
+    async with connect() as db:
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM materials WHERE subject_id=?",
+            (subject_id,),
+        )
+        (count,) = await cur.fetchone()
+    return count
+
+
+@translate_errors
+async def count_by_section(subject_id: int, section_id: int) -> int:
+    """Return number of materials for a subject-section pair."""
+
+    async with connect() as db:
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM materials WHERE subject_id=? AND section_id=?",
+            (subject_id, section_id),
+        )
+        (count,) = await cur.fetchone()
+    return count
+
+
+@translate_errors
+async def count_by_item_type(
+    subject_id: int, section_id: int, item_type_id: int
+) -> int:
+    """Return number of materials for a subject-section-item_type tuple."""
+
+    async with connect() as db:
+        cur = await db.execute(
+            """
+            SELECT COUNT(*) FROM materials
+            WHERE subject_id=? AND section_id=? AND item_type_id=?
+            """,
+            (subject_id, section_id, item_type_id),
+        )
+        (count,) = await cur.fetchone()
+    return count
+
+
+@translate_errors
+async def get_materials(
+    subject_id: int,
+    *,
+    section_id: int | None = None,
+    item_type_id: int | None = None,
+    year_id: int | None = None,
+    lecturer_id: int | None = None,
+    lecture_no: int | None = None,
+    include_disabled: bool = False,
+) -> list[dict]:
+    """Return materials filtered by various attributes."""
+
+    cols = ", ".join(f"m.{c}" for c in _MATERIAL_FIELDS)
+    query = f"""
+        SELECT {cols} FROM materials AS m
+        LEFT JOIN subject_section_enable AS sse
+            ON sse.subject_id = m.subject_id AND sse.section_id = m.section_id
+        LEFT JOIN sections AS s ON s.id = m.section_id
+        LEFT JOIN cards AS c ON c.id = m.category_id
+        LEFT JOIN section_item_types AS sit
+            ON sit.section_id = m.section_id AND sit.item_type_id = m.item_type_id
+        LEFT JOIN item_types AS it ON it.id = m.item_type_id
+        WHERE m.subject_id=?
+    """
+    params: list[int | str | None] = [subject_id]
+    if section_id is not None:
+        query += " AND m.section_id=?"
+        params.append(section_id)
+    if item_type_id is not None:
+        query += " AND m.item_type_id=?"
+        params.append(item_type_id)
+    if year_id is not None:
+        query += " AND m.year_id=?"
+        params.append(year_id)
+    if lecturer_id is not None:
+        query += " AND m.lecturer_id=?"
+        params.append(lecturer_id)
+    if lecture_no is not None:
+        query += " AND m.lecture_no=?"
+        params.append(lecture_no)
+    if not include_disabled:
+        query += (
+            " AND (s.is_enabled=1 OR s.id IS NULL)"
+            " AND (c.is_enabled=1 OR c.id IS NULL)"
+            " AND (it.is_enabled=1 OR it.id IS NULL)"
+            " AND (sse.is_enabled=1 OR sse.subject_id IS NULL)"
+            " AND (sit.is_enabled=1 OR sit.section_id IS NULL)"
+        )
+
+    async with connect() as db:
+        cur = await db.execute(query, params)
+        rows = await cur.fetchall()
+
+    return [_row_to_dict(r) for r in rows]

--- a/tests/test_repo_materials.py
+++ b/tests/test_repo_materials.py
@@ -1,28 +1,170 @@
 import asyncio
+import pytest
 
-from bot.repo import materials, taxonomy
+from bot.repo import materials, taxonomy, RepoConstraintError
 
 
-def test_materials_crud(repo_db):
-    sid = asyncio.run(taxonomy.create_section("نظري", "Theory"))["id"]
-    cid = asyncio.run(taxonomy.create_card("محاضرة", "Lecture", section_id=sid))["id"]
-    iid = asyncio.run(taxonomy.create_item_type("ملف", "File"))["id"]
-    mid = asyncio.run(
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_insert_validation(repo_db):
+    sid = _run(taxonomy.create_section("نظري", "Theory"))["id"]
+    cid = _run(taxonomy.create_card("محاضرة", "Lecture", section_id=sid))["id"]
+    iid = _run(taxonomy.create_item_type("ملف", "File"))["id"]
+
+    # both provided
+    with pytest.raises(RepoConstraintError):
+        _run(
+            materials.insert_material(
+                subject_id=1,
+                section_id=sid,
+                category_id=cid,
+                item_type_id=iid,
+                title="bad",
+            )
+        )
+
+    # neither provided
+    with pytest.raises(RepoConstraintError):
+        _run(
+            materials.insert_material(
+                subject_id=1,
+                section_id=sid,
+                category_id=None,
+                item_type_id=None,
+                title="bad",
+            )
+        )
+
+    # valid insert using item_type
+    mid = _run(
         materials.insert_material(
             subject_id=1,
             section_id=sid,
-            category_id=cid,
+            category_id=None,
+            item_type_id=iid,
+            title="ok",
+            content_hash="abc",
+        )
+    )
+    assert isinstance(mid, int)
+
+
+def test_crud_and_hash(repo_db):
+    sid = _run(taxonomy.create_section("نظري", "Theory"))["id"]
+    iid = _run(taxonomy.create_item_type("ملف", "File"))["id"]
+
+    mid = _run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=None,
             item_type_id=iid,
             title="Intro",
             content_hash="abc",
         )
     )
-    row = asyncio.run(materials.get_material(mid))
-    assert row[0] == mid
-    asyncio.run(materials.update_material_storage(mid, 10, 20, file_unique_id="x"))
-    row = asyncio.run(materials.get_material(mid))
-    assert row[11] == 10 and row[12] == 20 and row[13] == "x"
-    found = asyncio.run(materials.find_by_hash("abc"))
-    assert found[0] == mid
-    asyncio.run(materials.delete_material(mid))
-    assert asyncio.run(materials.get_material(mid)) is None
+    row = _run(materials.get_material(mid))
+    assert row["id"] == mid
+
+    # update storage info using generic update
+    row = _run(
+        materials.update_material(
+            mid,
+            tg_storage_chat_id=10,
+            tg_storage_msg_id=20,
+            file_unique_id="x",
+        )
+    )
+    assert row["tg_storage_chat_id"] == 10
+    assert row["tg_storage_msg_id"] == 20
+    assert row["file_unique_id"] == "x"
+
+    found = _run(materials.find_by_hash("abc"))
+    assert found and found["id"] == mid
+
+    deleted = _run(materials.delete_material(mid))
+    assert deleted["id"] == mid
+    assert _run(materials.get_material(mid)) is None
+
+
+def test_count_queries(repo_db):
+    sid = _run(taxonomy.create_section("نظري", "Theory"))["id"]
+    iid1 = _run(taxonomy.create_item_type("ملف", "File"))["id"]
+    iid2 = _run(taxonomy.create_item_type("رابط", "Link"))["id"]
+
+    _run(taxonomy.set_section_item_type(sid, iid1))
+    _run(taxonomy.set_section_item_type(sid, iid2))
+    _run(taxonomy.set_subject_section_enable(1, sid))
+
+    _run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=None,
+            item_type_id=iid1,
+            title="A",
+        )
+    )
+    _run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=None,
+            item_type_id=iid2,
+            title="B",
+        )
+    )
+
+    assert _run(materials.count_by_subject(1)) == 2
+    assert _run(materials.count_by_section(1, sid)) == 2
+    assert _run(materials.count_by_item_type(1, sid, iid1)) == 1
+
+
+def test_get_materials_filters_and_enable(repo_db):
+    sid = _run(taxonomy.create_section("نظري", "Theory"))["id"]
+    iid = _run(taxonomy.create_item_type("ملف", "File"))["id"]
+
+    _run(taxonomy.set_section_item_type(sid, iid))
+    _run(taxonomy.set_subject_section_enable(1, sid))
+
+    mid1 = _run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=None,
+            item_type_id=iid,
+            title="Y1L1",
+            year_id=1,
+            lecturer_id=1,
+            lecture_no=1,
+        )
+    )
+    mid2 = _run(
+        materials.insert_material(
+            subject_id=1,
+            section_id=sid,
+            category_id=None,
+            item_type_id=iid,
+            title="Y2L2",
+            year_id=2,
+            lecturer_id=2,
+            lecture_no=2,
+        )
+    )
+
+    # filter by year
+    res = _run(materials.get_materials(1, section_id=sid, year_id=1))
+    assert [r["id"] for r in res] == [mid1]
+
+    # filter by lecture number
+    res = _run(materials.get_materials(1, section_id=sid, lecture_no=2))
+    assert [r["id"] for r in res] == [mid2]
+
+    # disable section for subject
+    _run(taxonomy.set_subject_section_enable(1, sid, is_enabled=False))
+    res = _run(materials.get_materials(1, section_id=sid))
+    assert res == []
+    res = _run(materials.get_materials(1, section_id=sid, include_disabled=True))
+    assert {r["id"] for r in res} == {mid1, mid2}


### PR DESCRIPTION
## Summary
- enforce mutual exclusivity for `category_id` and `item_type_id`
- add dictionary based CRUD helpers and listing/count queries for materials
- enhance tests for repository material helpers

## Testing
- `pytest tests/test_repo_materials.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02b3802848329b6ac9c16094546ca