### PR TITLE
feat: extend RBAC repository with CRUD helpers

### DIFF
--- a/bot/handlers/rbac.py
+++ b/bot/handlers/rbac.py
@@ -17,8 +17,8 @@ async def create_role_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
     name = context.args[0]
     tags = context.args[1].split(",") if len(context.args) > 1 else []
-    role_id = await rbac.create_role(name, tags)
-    await update.effective_message.reply_text(f"Created role {role_id}")
+    role = await rbac.create_role(name, tags)
+    await update.effective_message.reply_text(f"Created role {role['id']}")
 
 
 async def assign_role_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/repo/rbac.py
+++ b/bot/repo/rbac.py
@@ -7,8 +7,20 @@ manage a specific group)."""
 from __future__ import annotations
 
 import json
+from typing import Any
 
-from . import connect, translate_errors
+from . import RepoNotFound, connect, translate_errors
+
+
+def _role_from_row(row: tuple[Any, ...]) -> dict:
+    """Convert a DB row to a role dictionary."""
+
+    return {
+        "id": row[0],
+        "name": row[1],
+        "tags": json.loads(row[2] or "[]"),
+        "is_enabled": bool(row[3]),
+    }
 
 
 @translate_errors
@@ -17,21 +29,8 @@ async def create_role(
     tags: list[str] | None = None,
     *,
     is_enabled: bool = True,
-) -> int:
-    """إنشاء دور جديد | Create a role and return its id.
-
-    Args:
-        name: اسم الدور / role name.
-        tags: وسوم اختيارية / optional tags.
-        is_enabled: هل الدور مفعّل؟ / enabled flag.
-
-    Returns:
-        int: معرف الدور / role id.
-
-    Raises:
-        RepoConstraintError: عند فشل القيود.
-        RepoError: أخطاء قاعدة البيانات.
-    """
+) -> dict:
+    """إنشاء دور جديد | Create a role and return its data."""
 
     async with connect() as db:
         cur = await db.execute(
@@ -39,96 +38,233 @@ async def create_role(
             (name, json.dumps(tags or []), int(is_enabled)),
         )
         await db.commit()
-        return cur.lastrowid
+        role_id = cur.lastrowid
+    return {
+        "id": role_id,
+        "name": name,
+        "tags": tags or [],
+        "is_enabled": is_enabled,
+    }
 
 
 @translate_errors
-async def assign_role(user_id: int, role_id: int) -> None:
-    """إسناد دور لمستخدم | Assign ``role_id`` to ``user_id``.
+async def get_role(role_id: int, *, is_enabled: bool | None = True) -> dict:
+    """Return a role by id respecting ``is_enabled`` filter."""
 
-    Args:
-        user_id: معرف المستخدم / user id.
-        role_id: معرف الدور / role id.
+    query = "SELECT id, name, tags, is_enabled FROM roles WHERE id=?"
+    params: list[Any] = [role_id]
+    if is_enabled is True:
+        query += " AND is_enabled=1"
+    elif is_enabled is False:
+        query += " AND is_enabled=0"
+    async with connect() as db:
+        cur = await db.execute(query, params)
+        row = await cur.fetchone()
+    if row is None:
+        raise RepoNotFound("role not found")
+    return _role_from_row(row)
 
-    Raises:
-        RepoError: أخطاء قاعدة البيانات.
-    """
 
+@translate_errors
+async def list_roles(is_enabled: bool | None = True) -> list[dict]:
+    """List roles optionally filtered by ``is_enabled``."""
+
+    query = "SELECT id, name, tags, is_enabled FROM roles"
+    if is_enabled is True:
+        query += " WHERE is_enabled=1"
+    elif is_enabled is False:
+        query += " WHERE is_enabled=0"
+    async with connect() as db:
+        cur = await db.execute(query)
+        rows = await cur.fetchall()
+    return [_role_from_row(row) for row in rows]
+
+
+@translate_errors
+async def update_role(
+    role_id: int,
+    *,
+    name: str | None = None,
+    tags: list[str] | None = None,
+    is_enabled: bool | None = None,
+    current_is_enabled: bool | None = True,
+) -> dict:
+    """Update role fields and return updated record."""
+
+    sets: list[str] = []
+    params: list[Any] = []
+    if name is not None:
+        sets.append("name=?")
+        params.append(name)
+    if tags is not None:
+        sets.append("tags=?")
+        params.append(json.dumps(tags))
+    if is_enabled is not None:
+        sets.append("is_enabled=?")
+        params.append(int(is_enabled))
+    if not sets:
+        return await get_role(role_id, is_enabled=current_is_enabled)
+
+    params.append(role_id)
+    query = f"UPDATE roles SET {', '.join(sets)} WHERE id=?"
+    if current_is_enabled is True:
+        query += " AND is_enabled=1"
+    elif current_is_enabled is False:
+        query += " AND is_enabled=0"
+
+    async with connect() as db:
+        cur = await db.execute(query, params)
+        if cur.rowcount == 0:
+            raise RepoNotFound("role not found")
+        await db.commit()
+
+    return await get_role(role_id, is_enabled=None)
+
+
+@translate_errors
+async def delete_role(role_id: int, *, is_enabled: bool | None = True) -> dict:
+    """Delete a role respecting ``is_enabled`` filter."""
+
+    query = "DELETE FROM roles WHERE id=?"
+    params: list[Any] = [role_id]
+    if is_enabled is True:
+        query += " AND is_enabled=1"
+    elif is_enabled is False:
+        query += " AND is_enabled=0"
+    async with connect() as db:
+        cur = await db.execute(query, params)
+        await db.commit()
+    if cur.rowcount == 0:
+        raise RepoNotFound("role not found")
+    return {"id": role_id}
+
+
+@translate_errors
+async def assign_role(user_id: int, role_id: int) -> dict:
+    """إسناد دور لمستخدم | Assign ``role_id`` to ``user_id``."""
+
+    # Ensure role is enabled
+    await get_role(role_id)
     async with connect() as db:
         await db.execute(
             "INSERT OR IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)",
             (user_id, role_id),
         )
         await db.commit()
+    return {"user_id": user_id, "role_id": role_id}
 
 
 @translate_errors
-async def revoke_role(user_id: int, role_id: int) -> None:
-    """إزالة دور من مستخدم | Remove ``role_id`` from ``user_id``.
-
-    Args:
-        user_id: معرف المستخدم / user id.
-        role_id: معرف الدور / role id.
-
-    Raises:
-        RepoError: أخطاء قاعدة البيانات.
-    """
+async def revoke_role(user_id: int, role_id: int) -> dict:
+    """إزالة دور من مستخدم | Remove ``role_id`` from ``user_id``."""
 
     async with connect() as db:
         await db.execute(
-            "DELETE FROM user_roles WHERE user_id=? AND role_id=?",
-            (user_id, role_id),
+            "DELETE FROM user_roles WHERE user_id=? AND role_id=? AND EXISTS (SELECT 1 FROM roles r WHERE r.id=? AND r.is_enabled=1)",
+            (user_id, role_id, role_id),
         )
         await db.commit()
+    return {"user_id": user_id, "role_id": role_id}
 
 
 @translate_errors
-async def set_permission(role_id: int, permission_key: str, scope: dict | None = None) -> None:
-    """تعيين صلاحية لدور | Set a permission for a role.
+async def list_user_roles(user_id: int, *, is_enabled: bool | None = True) -> list[dict]:
+    """List roles assigned to ``user_id``."""
 
-    Args:
-        role_id: معرف الدور / role id.
-        permission_key: مفتاح الصلاحية / permission key.
-        scope: نطاق اختياري بصيغة JSON / optional scope.
+    query = (
+        "SELECT r.id, r.name, r.tags, r.is_enabled FROM user_roles ur "
+        "JOIN roles r ON ur.role_id = r.id WHERE ur.user_id=?"
+    )
+    params: list[Any] = [user_id]
+    if is_enabled is True:
+        query += " AND r.is_enabled=1"
+    elif is_enabled is False:
+        query += " AND r.is_enabled=0"
+    async with connect() as db:
+        cur = await db.execute(query, params)
+        rows = await cur.fetchall()
+    return [_role_from_row(row) for row in rows]
 
-    Raises:
-        RepoError: أخطاء قاعدة البيانات.
-    """
 
+@translate_errors
+async def set_permission(role_id: int, permission_key: str, scope: dict | None = None) -> dict:
+    """تعيين صلاحية لدور | Set a permission for a role."""
+
+    await get_role(role_id)
     async with connect() as db:
         await db.execute(
             "INSERT OR REPLACE INTO role_permissions (role_id, permission_key, scope) VALUES (?, ?, ?)",
             (role_id, permission_key, json.dumps(scope)),
         )
         await db.commit()
+    return {"role_id": role_id, "permission_key": permission_key, "scope": scope}
 
 
 @translate_errors
-async def has_permission(user_id: int, permission_key: str, scope: dict | None = None) -> bool:
-    """تحقق من صلاحية مستخدم | Return True if user has permission.
+async def list_role_permissions(role_id: int, *, is_enabled: bool | None = True) -> list[dict]:
+    """List permissions for a role."""
 
-    Args:
-        user_id: معرف المستخدم / user id.
-        permission_key: مفتاح الصلاحية.
-        scope: نطاق اختياري / optional scope.
-
-    Returns:
-        bool: ``True`` إذا كانت الصلاحية موجودة / True if allowed.
-
-    Raises:
-        RepoError: أخطاء قاعدة البيانات.
-    """
-
+    query = (
+        "SELECT rp.permission_key, rp.scope FROM role_permissions rp "
+        "JOIN roles r ON rp.role_id = r.id WHERE rp.role_id=?"
+    )
+    params: list[Any] = [role_id]
+    if is_enabled is True:
+        query += " AND r.is_enabled=1"
+    elif is_enabled is False:
+        query += " AND r.is_enabled=0"
     async with connect() as db:
-        cur = await db.execute(
-            """
-            SELECT rp.scope FROM user_roles ur
-            JOIN role_permissions rp ON ur.role_id = rp.role_id
-            JOIN roles r ON r.id = rp.role_id
-            WHERE ur.user_id=? AND rp.permission_key=? AND r.is_enabled=1
-            """,
-            (user_id, permission_key),
-        )
+        cur = await db.execute(query, params)
+        rows = await cur.fetchall()
+    return [
+        {
+            "role_id": role_id,
+            "permission_key": key,
+            "scope": json.loads(scope) if scope else None,
+        }
+        for key, scope in rows
+    ]
+
+
+@translate_errors
+async def delete_permission(role_id: int, permission_key: str, *, is_enabled: bool | None = True) -> dict:
+    """Remove a permission from a role."""
+
+    query = "DELETE FROM role_permissions WHERE role_id=? AND permission_key=?"
+    params: list[Any] = [role_id, permission_key]
+    if is_enabled is True:
+        query += " AND EXISTS (SELECT 1 FROM roles r WHERE r.id=? AND r.is_enabled=1)"
+        params.append(role_id)
+    elif is_enabled is False:
+        query += " AND EXISTS (SELECT 1 FROM roles r WHERE r.id=? AND r.is_enabled=0)"
+        params.append(role_id)
+    async with connect() as db:
+        await db.execute(query, params)
+        await db.commit()
+    return {"role_id": role_id, "permission_key": permission_key}
+
+
+@translate_errors
+async def has_permission(
+    user_id: int,
+    permission_key: str,
+    scope: dict | None = None,
+    *,
+    is_enabled: bool = True,
+) -> bool:
+    """تحقق من صلاحية مستخدم | Return True if user has permission."""
+
+    query = (
+        "SELECT rp.scope FROM user_roles ur "
+        "JOIN role_permissions rp ON ur.role_id = rp.role_id "
+        "JOIN roles r ON r.id = rp.role_id "
+        "WHERE ur.user_id=? AND rp.permission_key=?"
+    )
+    params: list[Any] = [user_id, permission_key]
+    if is_enabled:
+        query += " AND r.is_enabled=1"
+    async with connect() as db:
+        cur = await db.execute(query, params)
         rows = await cur.fetchall()
         if not rows:
             return False
@@ -144,29 +280,19 @@ async def has_permission(user_id: int, permission_key: str, scope: dict | None =
 
 
 @translate_errors
-async def users_with_tag(tag: str) -> list[int]:
-    """إرجاع المستخدمين حسب الوسم | Return user ids for roles tagged with ``tag``.
+async def users_with_tag(tag: str, *, is_enabled: bool = True) -> list[int]:
+    """إرجاع المستخدمين حسب الوسم | Return user ids for roles tagged with ``tag``."""
 
-    Args:
-        tag: الوسم المطلوب / tag value.
-
-    Returns:
-        list[int]: قائمة المعرفات / list of user ids.
-
-    Raises:
-        RepoError: أخطاء قاعدة البيانات.
-    """
-
+    query = (
+        "SELECT DISTINCT ur.user_id FROM roles r "
+        "JOIN user_roles ur ON r.id = ur.role_id "
+        "JOIN json_each(r.tags) jt WHERE jt.value = ?"
+    )
+    params: list[Any] = [tag]
+    if is_enabled:
+        query += " AND r.is_enabled = 1"
     async with connect() as db:
-        cur = await db.execute(
-            """
-            SELECT DISTINCT ur.user_id FROM roles r
-            JOIN user_roles ur ON r.id = ur.role_id
-            JOIN json_each(r.tags) jt
-            WHERE jt.value = ? AND r.is_enabled = 1
-            """,
-            (tag,),
-        )
+        cur = await db.execute(query, params)
         return [row[0] for row in await cur.fetchall()]
 
 
@@ -194,9 +320,16 @@ async def broadcast(tag: str, message: str, send_func) -> int:
 
 __all__ = [
     "create_role",
+    "get_role",
+    "list_roles",
+    "update_role",
+    "delete_role",
     "assign_role",
+    "list_user_roles",
     "revoke_role",
     "set_permission",
+    "list_role_permissions",
+    "delete_permission",
     "has_permission",
     "broadcast",
     "users_with_tag",

--- a/docs/RBAC_GUIDE.md
+++ b/docs/RBAC_GUIDE.md
@@ -14,11 +14,11 @@ import asyncio
 from bot.repo import rbac
 
 # create a role and give it a permission
-role_id = asyncio.run(rbac.create_role("mod"))
-asyncio.run(rbac.set_permission(role_id, "upload"))
+role = asyncio.run(rbac.create_role("mod"))
+asyncio.run(rbac.set_permission(role["id"], "upload"))
 
 # assign the role to a user
-asyncio.run(rbac.assign_role(1234, role_id))
+asyncio.run(rbac.assign_role(1234, role["id"]))
 
 # check a permission
 assert asyncio.run(rbac.has_permission(1234, "upload"))

--- a/tests/integration/test_acceptance.py
+++ b/tests/integration/test_acceptance.py
@@ -159,9 +159,9 @@ async def test_sensitivity_block(monkeypatch):
 
 
 def test_rbac_integration(repo_db):
-    role_id = asyncio.run(rbac.create_role("mod", ["mods"]))
-    asyncio.run(rbac.assign_role(1, role_id))
-    asyncio.run(rbac.set_permission(role_id, "delete"))
+    role = asyncio.run(rbac.create_role("mod", ["mods"]))
+    asyncio.run(rbac.assign_role(1, role["id"]))
+    asyncio.run(rbac.set_permission(role["id"], "delete"))
     assert asyncio.run(rbac.has_permission(1, "delete"))
 
 

--- a/tests/test_repo_rbac.py
+++ b/tests/test_repo_rbac.py
@@ -1,13 +1,38 @@
 import asyncio
+import pytest
 
-from bot.repo import rbac
+from bot.repo import RepoNotFound, rbac
 
 
-def test_rbac_basic(repo_db):
-    role_id = asyncio.run(rbac.create_role("mod", ["mods"]))
-    asyncio.run(rbac.assign_role(1, role_id))
-    asyncio.run(rbac.set_permission(role_id, "delete"))
+def test_roles_crud(repo_db):
+    role = asyncio.run(rbac.create_role("mod", ["mods"]))
+    disabled = asyncio.run(rbac.create_role("old", is_enabled=False))
+
+    fetched = asyncio.run(rbac.get_role(role["id"]))
+    assert fetched["name"] == "mod"
+
+    with pytest.raises(RepoNotFound):
+        asyncio.run(rbac.get_role(disabled["id"]))
+    assert len(asyncio.run(rbac.list_roles())) == 1
+    assert len(asyncio.run(rbac.list_roles(is_enabled=None))) == 2
+
+    updated = asyncio.run(rbac.update_role(role["id"], name="moderator"))
+    assert updated["name"] == "moderator"
+
+    asyncio.run(rbac.delete_role(role["id"]))
+    remaining = asyncio.run(rbac.list_roles(is_enabled=None))
+    assert [r["id"] for r in remaining] == [disabled["id"]]
+
+
+def test_user_roles_and_permissions(repo_db):
+    role = asyncio.run(rbac.create_role("mod", ["mods"]))
+    asyncio.run(rbac.assign_role(1, role["id"]))
+    assert [r["id"] for r in asyncio.run(rbac.list_user_roles(1))] == [role["id"]]
+
+    asyncio.run(rbac.set_permission(role["id"], "delete"))
     assert asyncio.run(rbac.has_permission(1, "delete")) is True
+    perms = asyncio.run(rbac.list_role_permissions(role["id"]))
+    assert perms == [{"role_id": role["id"], "permission_key": "delete", "scope": None}]
 
     sent: list[tuple[int, str]] = []
 
@@ -17,10 +42,9 @@ def test_rbac_basic(repo_db):
     asyncio.run(rbac.broadcast("mods", "hello", _send))
     assert sent == [(1, "hello")]
 
+    asyncio.run(rbac.delete_permission(role["id"], "delete"))
+    assert asyncio.run(rbac.has_permission(1, "delete")) is False
 
-def test_rbac_context_scope(repo_db):
-    role_id = asyncio.run(rbac.create_role("group_mod"))
-    asyncio.run(rbac.assign_role(2, role_id))
-    asyncio.run(rbac.set_permission(role_id, "manage_group", {"group_id": 5}))
-    assert asyncio.run(rbac.has_permission(2, "manage_group", {"group_id": 5})) is True
-    assert asyncio.run(rbac.has_permission(2, "manage_group", {"group_id": 6})) is False
+    asyncio.run(rbac.revoke_role(1, role["id"]))
+    assert asyncio.run(rbac.list_user_roles(1)) == []
+


### PR DESCRIPTION
## Summary
- expand RBAC repository with CRUD helpers for roles, user roles, and permissions
- add get_role and list_roles utilities for admin use
- document and test new RBAC CRUD operations

## Testing
- `pytest tests/test_repo_rbac.py tests/integration/test_acceptance.py::test_rbac_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_68c02e7beccc8329b6c156dcb135dee4