### PR TITLE
feat: normalize hashtags in caption parser

### DIFF
--- a/tests/test_caption_parser.py
+++ b/tests/test_caption_parser.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from bot.parser.caption_parser import parse_message
+
+
+def test_parse_message_extracts_normalized_hashtags():
+    text = "انظر إلى #Te‏ST1 و#PHYsics١ و#physics1 و#تجربة‏ #تجربة"
+    result, error = asyncio.run(parse_message(text))
+    assert error is None
+    assert result.hashtags == ["test1", "physics1", "تجربة"]


### PR DESCRIPTION
## Summary
- extract hashtags from message text with regex and deduplicate
- normalize digits and case using repo mapping
- test hashtag extraction and normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c049eaf82083298db962ddc588788f