### PR TITLE
Validate content tags during caption parsing

### DIFF
--- a/bot/parser/caption_parser.py
+++ b/bot/parser/caption_parser.py
@@ -28,6 +28,7 @@ class ParseResult:
     tg_topic_id: Optional[int] = None
     locale: Optional[str] = None
     hashtags: Optional[List[dict]] = None
+    content_tag: Optional[dict] = None
 
 
 @dataclass
@@ -69,9 +70,31 @@ async def parse_message(
                 tg_topic_id=tg_topic_id,
                 locale=user_locale,
                 hashtags=None,
+                content_tag=None,
             )
             return result, ParseError("E-HT-UNKNOWN")
         tags.append(resolved)
+    content_tags = [t for t in tags if t.get("is_content_tag")]
+    if not content_tags:
+        result = ParseResult(
+            text=message_text,
+            group_id=group_id,
+            tg_topic_id=tg_topic_id,
+            locale=user_locale,
+            hashtags=tags or None,
+            content_tag=None,
+        )
+        return result, ParseError("E-NO-CONTENT-TAG")
+    if len(content_tags) > 1:
+        result = ParseResult(
+            text=message_text,
+            group_id=group_id,
+            tg_topic_id=tg_topic_id,
+            locale=user_locale,
+            hashtags=tags or None,
+            content_tag=None,
+        )
+        return result, ParseError("E-HT-MULTI")
 
     result = ParseResult(
         text=message_text,
@@ -79,6 +102,7 @@ async def parse_message(
         tg_topic_id=tg_topic_id,
         locale=user_locale,
         hashtags=tags or None,
+        content_tag=content_tags[0],
     )
     return result, None
 

--- a/tests/test_caption_parser.py
+++ b/tests/test_caption_parser.py
@@ -6,9 +6,10 @@ from bot.repo import hashtags
 
 def test_parse_message_resolves_normalized_hashtags(repo_db):
     async def setup() -> None:
-        for idx, tag in enumerate(["test1", "physics1", "تجربة"], start=1):
+        tags = [("test1", False), ("physics1", True), ("تجربة", False)]
+        for idx, (tag, is_ct) in enumerate(tags, start=1):
             aid = await hashtags.create_alias(tag)
-            await hashtags.create_mapping(aid, "subject", idx)
+            await hashtags.create_mapping(aid, "subject", idx, is_content_tag=is_ct)
 
     asyncio.run(setup())
 
@@ -17,6 +18,12 @@ def test_parse_message_resolves_normalized_hashtags(repo_db):
     assert error is None
     assert len(result.hashtags) == 3
     assert all(h["target_kind"] == "subject" for h in result.hashtags)
+    assert result.content_tag == {
+        "target_kind": "subject",
+        "target_id": 2,
+        "is_content_tag": True,
+        "overrides": None,
+    }
 
 
 def test_parse_message_unknown_hashtag(repo_db):
@@ -31,3 +38,33 @@ def test_parse_message_unknown_hashtag(repo_db):
     assert isinstance(error, ParseError)
     assert error.message == "E-HT-UNKNOWN"
     assert result.hashtags is None
+    assert result.content_tag is None
+
+
+def test_parse_message_no_content_tag_error(repo_db):
+    async def setup() -> None:
+        aid = await hashtags.create_alias("test")
+        await hashtags.create_mapping(aid, "subject", 1)
+
+    asyncio.run(setup())
+
+    result, error = asyncio.run(parse_message("#test"))
+    assert isinstance(error, ParseError)
+    assert error.message == "E-NO-CONTENT-TAG"
+    assert result.content_tag is None
+    assert len(result.hashtags) == 1
+
+
+def test_parse_message_multiple_content_tags_error(repo_db):
+    async def setup() -> None:
+        for idx, tag in enumerate(["a", "b"], start=1):
+            aid = await hashtags.create_alias(tag)
+            await hashtags.create_mapping(aid, "subject", idx, is_content_tag=True)
+
+    asyncio.run(setup())
+
+    result, error = asyncio.run(parse_message("#a #b"))
+    assert isinstance(error, ParseError)
+    assert error.message == "E-HT-MULTI"
+    assert result.content_tag is None
+    assert len(result.hashtags) == 2


### PR DESCRIPTION
## Summary
- track a dedicated `content_tag` in `ParseResult`
- error on missing or multiple content tags in `parse_message`
- expand caption parser tests for content tag scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04c17b0d883298c6c4cbcdb32e614