### PR TITLE
Add context parsing via topic and hashtags

### DIFF
--- a/bot/parser/context.py
+++ b/bot/parser/context.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from ..repo import RepoNotFound, hashtags, linking
+from .caption_parser import ParseError
+
+
+@dataclass
+class ContextResult:
+    """Binding information resolved from topic or hashtags."""
+
+    subject_id: int
+    section_id: Optional[int]
+    source: str
+
+
+async def parse_context(
+    group_id: int,
+    tg_topic_id: Optional[int],
+    tags: List[str],
+) -> Tuple[Optional[ContextResult], Optional[ParseError]]:
+    """Resolve subject/section context for a message.
+
+    If *tg_topic_id* is provided, the binding is retrieved via
+    :func:`linking.get_binding_by_topic` and ``source`` is set to ``'topic'``.
+    Otherwise, hashtags are inspected to locate both a subject and section tag
+    from :mod:`hashtag_mappings`.  When either tag is missing, a
+    ``ParseError('E-NO-CONTEXT')`` is returned.
+    """
+
+    if tg_topic_id is not None:
+        try:
+            binding = await linking.get_binding_by_topic(group_id, tg_topic_id)
+        except RepoNotFound:
+            return None, ParseError("E-NO-CONTEXT")
+        return (
+            ContextResult(
+                subject_id=binding["subject_id"],
+                section_id=binding.get("section_id"),
+                source="topic",
+            ),
+            None,
+        )
+
+    subject_id: Optional[int] = None
+    section_id: Optional[int] = None
+    for raw in tags:
+        token = raw.split()[0].lstrip("#")
+        mappings = await hashtags.lookup_targets(token)
+        for kind, ident in mappings:
+            if kind == "subject" and subject_id is None:
+                subject_id = ident
+            elif kind == "section" and section_id is None:
+                section_id = ident
+        if subject_id is not None and section_id is not None:
+            break
+
+    if subject_id is None or section_id is None:
+        return None, ParseError("E-NO-CONTEXT")
+
+    return (
+        ContextResult(
+            subject_id=subject_id,
+            section_id=section_id,
+            source="hashtags",
+        ),
+        None,
+    )
+
+
+__all__ = ["parse_context", "ContextResult", "ParseError"]

--- a/tests/test_context_parser.py
+++ b/tests/test_context_parser.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from bot.parser.context import parse_context, ContextResult, ParseError
+from bot.repo import hashtags, linking
+
+pytestmark = pytest.mark.anyio
+
+
+async def _setup_hashtags():
+    sid_alias = await hashtags.create_alias("physics")
+    await hashtags.create_mapping(sid_alias, "subject", 1)
+    sec_alias = await hashtags.create_alias("theory")
+    await hashtags.create_mapping(sec_alias, "section", 2)
+
+
+async def test_resolve_from_topic(repo_db):
+    gid = await linking.upsert_group(100, "G")
+    await linking.upsert_topic(gid, 5, 1, section_id=2)
+    ctx, err = await parse_context(gid, 5, [])
+    assert err is None
+    assert ctx == ContextResult(subject_id=1, section_id=2, source="topic")
+
+
+async def test_resolve_from_hashtags(repo_db):
+    await _setup_hashtags()
+    ctx, err = await parse_context(1, None, ["#physics", "#theory"])
+    assert err is None
+    assert ctx == ContextResult(subject_id=1, section_id=2, source="hashtags")
+
+
+async def test_missing_context_error(repo_db):
+    await _setup_hashtags()
+    ctx, err = await parse_context(1, None, ["#physics"])
+    assert ctx is None
+    assert isinstance(err, ParseError)
+    assert err.message == "E-NO-CONTEXT"


### PR DESCRIPTION
## Summary
- add `parse_context` to resolve subject/section via topic binding or hashtag mappings
- test topic binding, hashtag fallback, and missing context errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04ef4a4048329aaab1a3fe9316616