### PR TITLE
Handle year and lecturer tags with override support

### DIFF
--- a/bot/parser/caption_parser.py
+++ b/bot/parser/caption_parser.py
@@ -10,10 +10,14 @@ containers so the rest of the codebase can interact with a stable API.
 """
 
 from dataclasses import dataclass
+import json
 import re
 from typing import List, Optional, Tuple
 
 from ..repo import RepoNotFound, hashtags
+from ..utils.formatting import to_display_name
+from .hashtags import YEAR_TAG_RE, LECTURER_PREFIXES
+from . import helpers
 
 BIDI_RE = re.compile(r"[\u200e\u200f\u202a-\u202e]")
 HASHTAG_RE = re.compile(r"#([^\s#]+)")
@@ -29,6 +33,8 @@ class ParseResult:
     locale: Optional[str] = None
     hashtags: Optional[List[dict]] = None
     content_tag: Optional[dict] = None
+    year: Optional[int] = None
+    lecturer: Optional[str] = None
 
 
 @dataclass
@@ -54,13 +60,35 @@ async def parse_message(
     """
 
     clean_text = BIDI_RE.sub("", message_text)
+    matches = list(HASHTAG_RE.finditer(clean_text))
+    helpers.raw_tags = [m.group(0) for m in matches]
     seen: set[str] = set()
     tags: List[dict] = []
-    for tag in HASHTAG_RE.findall(clean_text):
+    content_tags: List[dict] = []
+    year: Optional[int] = None
+    lecturer: Optional[str] = None
+    for m in matches:
+        tag = m.group(1)
         normalized = hashtags.normalize_alias(tag)
         if normalized in seen:
             continue
         seen.add(normalized)
+
+        m_year = YEAR_TAG_RE.match(f"#{normalized}")
+        if m_year and year is None:
+            y = int(m_year.group(1))
+            if 1300 <= y <= 1600 or 1900 <= y <= 2100:
+                year = y
+            continue
+
+        if lecturer is None:
+            for p in LECTURER_PREFIXES:
+                if normalized.startswith(p):
+                    lecturer = to_display_name(normalized[len(p):])
+                    break
+            if lecturer is not None:
+                continue
+
         try:
             resolved = await hashtags.resolve_content_tag(normalized)
         except RepoNotFound:
@@ -71,10 +99,13 @@ async def parse_message(
                 locale=user_locale,
                 hashtags=None,
                 content_tag=None,
+                year=year,
+                lecturer=lecturer,
             )
             return result, ParseError("E-HT-UNKNOWN")
         tags.append(resolved)
-    content_tags = [t for t in tags if t.get("is_content_tag")]
+        if resolved.get("is_content_tag"):
+            content_tags.append(resolved)
     if not content_tags:
         result = ParseResult(
             text=message_text,
@@ -83,6 +114,8 @@ async def parse_message(
             locale=user_locale,
             hashtags=tags or None,
             content_tag=None,
+            year=year,
+            lecturer=lecturer,
         )
         return result, ParseError("E-NO-CONTENT-TAG")
     if len(content_tags) > 1:
@@ -93,8 +126,23 @@ async def parse_message(
             locale=user_locale,
             hashtags=tags or None,
             content_tag=None,
+            year=year,
+            lecturer=lecturer,
         )
         return result, ParseError("E-HT-MULTI")
+
+    content_tag = content_tags[0]
+    overrides_data = {}
+    overrides = content_tag.get("overrides")
+    if overrides:
+        try:
+            overrides_data = json.loads(overrides)
+        except Exception:
+            overrides_data = {}
+    if not overrides_data.get("allows_year", True):
+        year = None
+    if not overrides_data.get("allows_lecturer", True):
+        lecturer = None
 
     result = ParseResult(
         text=message_text,
@@ -102,7 +150,9 @@ async def parse_message(
         tg_topic_id=tg_topic_id,
         locale=user_locale,
         hashtags=tags or None,
-        content_tag=content_tags[0],
+        content_tag=content_tag,
+        year=year,
+        lecturer=lecturer,
     )
     return result, None
 

--- a/bot/parser/hashtags.py
+++ b/bot/parser/hashtags.py
@@ -22,6 +22,7 @@ import re
 from typing import Iterable, List, Tuple
 
 from ..utils.formatting import arabic_ordinal, to_display_name, ARABIC_ORDINALS
+from . import helpers
 
 # ---------------------------------------------------------------------------
 # Normalisation helpers
@@ -275,6 +276,7 @@ def parse_hashtags(text: str) -> Tuple[ParsedHashtags, str | None]:
 
     cleaned = _clean(text or "")
     tags = _split_lines(cleaned)
+    helpers.raw_tags = tags.copy()
     info = ParsedHashtags(tags=tags)
     sequence: List[str] = []
 
@@ -298,7 +300,7 @@ def parse_hashtags(text: str) -> Tuple[ParsedHashtags, str | None]:
         m = YEAR_TAG_RE.match(token)
         if m and info.year is None:
             y = int(m.group(1))
-            if 1300 <= y <= 1600:
+            if 1300 <= y <= 1600 or 1900 <= y <= 2100:
                 info.year = y
                 sequence.append("year")
                 continue

--- a/bot/parser/helpers.py
+++ b/bot/parser/helpers.py
@@ -1,0 +1,10 @@
+"""Helper utilities for parser debugging."""
+from __future__ import annotations
+
+from typing import List
+
+# This module exposes ``raw_tags`` which is populated by parsers to aid tests
+# and debugging by capturing the raw hashtags extracted from message text.
+raw_tags: List[str] | None = None
+
+__all__ = ["raw_tags"]


### PR DESCRIPTION
## Summary
- parse caption hashtags for Hijri/Gregorian years and lecturer names
- honor `allows_year` and `allows_lecturer` overrides when present
- expose `helpers.raw_tags` for debugging raw hashtag tokens

## Testing
- `pytest tests/test_caption_parser.py tests/test_hashtags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05344abcc83299804eb6c379e6f06