### PR TITLE
Handle chain intent markers within messages

### DIFF
--- a/tests/test_hashtags.py
+++ b/tests/test_hashtags.py
@@ -77,3 +77,10 @@ def test_parse_hashtags_content_type(tag, expected):
     info, error = parse_hashtags(tag)
     assert error is None
     assert info.content_type == expected
+
+
+def test_parse_hashtags_chain_intent():
+    info, error = parse_hashtags("#study_plan //follow")
+    assert error is None
+    assert info.content_type == "study_plan"
+    assert info.chain.intent == "follow"


### PR DESCRIPTION
## Summary
- detect `//follow`, `//end`, and `//cancel` markers at the end of text and expose parsed intent
- manage follow-chain lifecycle in ingestion handler based on parsed intent
- update and expand tests for inline chain commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c059f5d3d48329a0e6ede69595015e