### PR TITLE
Extend caption parser with context and chain support

### DIFF
--- a/bot/parser/context.py
+++ b/bot/parser/context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from ..repo import RepoNotFound, hashtags, linking
-from .caption_parser import ParseError
+from .errors import ParseError
 
 
 @dataclass

--- a/bot/parser/errors.py
+++ b/bot/parser/errors.py
@@ -1,0 +1,17 @@
+"""Common parsing error container."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ParseError:
+    """Information about a parsing error."""
+
+    message: str
+    details: Optional[str] = None
+
+
+__all__ = ["ParseError"]
+

--- a/bot/parser/session.py
+++ b/bot/parser/session.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import re
 from typing import Optional, Tuple
 
-from .caption_parser import ParseError
+from .errors import ParseError
 from ..repo import taxonomy
 from ..utils.formatting import ARABIC_ORDINALS
 


### PR DESCRIPTION
## Summary
- include lecture number, subject/section context, chain intent, and raw tag list in ParseResult
- factor out ParseError into a shared module

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c05c408ee08329a95330e61f935ee6