### PR TITLE
Refactor navigation stack node

### DIFF
--- a/bot/navigation/nav_stack.py
+++ b/bot/navigation/nav_stack.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
-from typing import Dict, List, Tuple, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 # Key used to store the navigation stack in ``context.user_data``
 NAV_STACK_KEY = "nav_stack"
 
-# Node representation: (kind, id, title)
-Node = Tuple[str, Optional[int | str | tuple[int, int]], str]
+@dataclass
+class Node:
+    """Represents a single entry on the navigation stack."""
+
+    kind: str
+    ident: Optional[Any]
+    title: str = ""
 
 
 class NavStack:
     """Simple navigation stack backed by ``context.user_data``.
 
-    The stack is stored under :data:`NAV_STACK_KEY` in ``user_data`` and uses a
-    list of tuples ``(kind, id, title)`` to ease serialization.
+    The stack is stored under :data:`NAV_STACK_KEY` in ``user_data`` and uses
+    :class:`Node` instances to ease serialization.
     """
 
     def __init__(self, user_data: Dict) -> None:
@@ -49,4 +55,9 @@ class NavStack:
     # ------------------------------------------------------------------
     def path_text(self) -> str:
         """Return a textual representation of the current path."""
-        return " / ".join(title for _, _, title in self._stack if title)
+        return " / ".join(node.title for node in self._stack if node.title)
+
+    # ------------------------------------------------------------------
+    def state(self) -> List[Node]:
+        """Return a copy of the current navigation stack."""
+        return list(self._stack)

--- a/tests/test_nav_stack.py
+++ b/tests/test_nav_stack.py
@@ -1,4 +1,4 @@
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 def test_nav_stack_basic_operations():
@@ -8,14 +8,15 @@ def test_nav_stack_basic_operations():
     # initial stack created under NAV_STACK_KEY
     assert user_data["nav_stack"] == []
 
-    node1 = ("level", 1, "Level 1")
-    node2 = ("term", 2, "Term 1")
+    node1 = Node("level", 1, "Level 1")
+    node2 = Node("term", 2, "Term 1")
 
     stack.push(node1)
     stack.push(node2)
 
     assert stack.peek() == node2
     assert stack.path_text() == "Level 1 / Term 1"
+    assert stack.state() == [node1, node2]
 
     popped = stack.pop()
     assert popped == node2
@@ -27,3 +28,6 @@ def test_nav_stack_basic_operations():
     assert stack.pop() is None
     assert stack.peek() is None
     assert stack.path_text() == ""
+
+    # state should return a copy of nodes
+    assert stack.state() == []

--- a/tests/test_navigation_cards.py
+++ b/tests/test_navigation_cards.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OWNER_TG_ID", "1")
 
 from bot.db import base as db_base
 from bot.db import subjects, materials
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 class DummyMessage:
@@ -47,10 +47,10 @@ def test_card_button_sends_material(tmp_path):
 
         ctx = SimpleNamespace(user_data={})
         stack = NavStack(ctx.user_data)
-        stack.push(("level", 1, "L1"))
-        stack.push(("term", (1, 1), "T1"))
-        stack.push(("term_option", (1, 1), "عرض المواد"))
-        stack.push(("subject", 1, "Sub1"))
+        stack.push(Node("level", 1, "L1"))
+        stack.push(Node("term", (1, 1), "T1"))
+        stack.push(Node("term_option", (1, 1), "عرض المواد"))
+        stack.push(Node("subject", 1, "Sub1"))
 
         copy_calls = []
 
@@ -84,7 +84,7 @@ def test_card_button_sends_material(tmp_path):
         )
 
         stack = NavStack(ctx.user_data)
-        assert stack.peek()[0] == "subject"
+        assert stack.peek() and stack.peek().kind == "subject"
 
     asyncio.run(_inner())
 

--- a/tests/test_navigation_categories.py
+++ b/tests/test_navigation_categories.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OWNER_TG_ID", "1")
 
 from bot.db import base as db_base
 from bot.db import subjects, materials
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 CATEGORIES = [
@@ -80,8 +80,8 @@ def test_section_category_buttons_send_material(tmp_path):
             assert ("section_option", f"1-theory-{cat}", label) in children
 
         stack = NavStack(ctx.user_data)
-        stack.push(("subject", 1, "Sub1"))
-        stack.push(("section", (1, "theory"), "نظري 📘"))
+        stack.push(Node("subject", 1, "Sub1"))
+        stack.push(Node("section", (1, "theory"), "نظري 📘"))
 
         copy_calls = []
 

--- a/tests/test_navigation_section_skip.py
+++ b/tests/test_navigation_section_skip.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OWNER_TG_ID", "1")
 
 from bot.db import base as db_base
 from bot.db import subjects, materials, rbac
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 CATEGORIES = [
@@ -75,9 +75,9 @@ def _setup_db(tmp_path, with_lab=False):
 
 def _build_initial_stack(ctx):
     stack = NavStack(ctx.user_data)
-    stack.push(("level", 1, "L1"))
-    stack.push(("term", (1, 1), "T1"))
-    stack.push(("term_option", (1, 1), "عرض المواد"))
+    stack.push(Node("level", 1, "L1"))
+    stack.push(Node("term", (1, 1), "T1"))
+    stack.push(Node("term_option", (1, 1), "عرض المواد"))
     return stack
 
 
@@ -106,7 +106,7 @@ def test_single_section_does_not_skip(tmp_path):
     asyncio.run(navtree.navtree_callback(update, context))
 
     stack = NavStack(ctx.user_data)
-    assert stack.peek()[0] == "subject"
+    assert stack.peek() and stack.peek().kind == "subject"
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]
@@ -139,7 +139,7 @@ def test_multiple_sections_no_skip_and_no_categories(tmp_path):
     asyncio.run(navtree.navtree_callback(update, context))
 
     stack = NavStack(ctx.user_data)
-    assert stack.peek()[0] == "subject"
+    assert stack.peek() and stack.peek().kind == "subject"
 
     keyboard = message.sent[-1][1]
     buttons = [b.callback_data for row in keyboard.inline_keyboard for b in row]

--- a/tests/test_navigation_syllabus.py
+++ b/tests/test_navigation_syllabus.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OWNER_TG_ID", "1")
 
 from bot.db import base as db_base
 from bot.db import subjects, materials
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 class DummyMessage:
@@ -57,7 +57,7 @@ def test_syllabus_section_sends_material(tmp_path):
         assert ("card", "1:syllabus", "التوصيف 📄") in children
 
         stack = NavStack(ctx.user_data)
-        stack.push(("subject", 1, "Sub1"))
+        stack.push(Node("subject", 1, "Sub1"))
 
         copy_calls = []
 

--- a/tests/test_navigation_tree.py
+++ b/tests/test_navigation_tree.py
@@ -11,7 +11,7 @@ os.environ.setdefault("BOT_TOKEN", "test")
 os.environ.setdefault("ARCHIVE_CHANNEL_ID", "1")
 os.environ.setdefault("OWNER_TG_ID", "1")
 
-from bot.navigation import NavStack
+from bot.navigation.nav_stack import NavStack, Node
 
 
 class DummyMessage:
@@ -33,12 +33,12 @@ def navtree():
 def test_nav_stack_path():
     ud_new = {}
     stack = NavStack(ud_new)
-    stack.push(("level", 1, "L1"))
-    stack.push(("term", 1, "T1"))
-    stack.push(("subject", 1, "S1"))
-    stack.push(("year", 1, "Y1"))
-    stack.push(("section", "sec", "Sec"))
-    stack.push(("lecture", None, "Mat"))
+    stack.push(Node("level", 1, "L1"))
+    stack.push(Node("term", 1, "T1"))
+    stack.push(Node("subject", 1, "S1"))
+    stack.push(Node("year", 1, "Y1"))
+    stack.push(Node("section", "sec", "Sec"))
+    stack.push(Node("lecture", None, "Mat"))
     new_path = stack.path_text()
 
     assert new_path == "L1 / T1 / S1 / Y1 / Sec / Mat"
@@ -73,8 +73,8 @@ def test_db_time_logged(large_dataset, caplog):
 def test_back_button_pops_stack(monkeypatch, navtree):
     context = SimpleNamespace(user_data={})
     stack = NavStack(context.user_data)
-    stack.push(("level", 1, "L1"))
-    stack.push(("term", 2, "T1"))
+    stack.push(Node("level", 1, "L1"))
+    stack.push(Node("term", 2, "T1"))
 
     query = SimpleNamespace(data="nav:back", message=DummyMessage(), answer=AsyncMock())
     update = SimpleNamespace(callback_query=query, effective_user=None)
@@ -91,9 +91,9 @@ def test_back_button_pops_stack(monkeypatch, navtree):
 def test_back_from_single_section_returns_to_subject(monkeypatch, navtree):
     context = SimpleNamespace(user_data={})
     stack = NavStack(context.user_data)
-    stack.push(("term", 1, "T1"))
-    stack.push(("subject", 7, "S1"))
-    stack.push(("section", "7:only", "Only"))
+    stack.push(Node("term", 1, "T1"))
+    stack.push(Node("subject", 7, "S1"))
+    stack.push(Node("section", "7:only", "Only"))
 
     query = SimpleNamespace(
         data="nav:back",


### PR DESCRIPTION
## Summary
- represent navigation stack entries with a Node dataclass that includes kind, ident and title
- update stack operations and handlers to use the dataclass and add a `state` helper
- adjust tests to cover new dataclass-based stack

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2189301848329828b28a6205edf3b